### PR TITLE
Avoid FP16 warning on CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
 ## Layout
 
 - `public_html/index.php` – PHP entry point that calls the Python helper.
-- `script/whisper_transcribe.py` – Python script performing the transcription.
+- `script/whisper_transcribe.py` – Python script performing the transcription. It
+  selects FP16 on GPUs and uses FP32 on CPUs to avoid precision warnings.
 - `script/convert_all.bat` – Windows helper to batch transcribe `.wav` files.
 - `config_files/config.php` – configuration for paths including the sound directory.
 - `documents/`, `business_information/`, `etc/` – placeholders for project

--- a/script/test_whisper_transcribe.py
+++ b/script/test_whisper_transcribe.py
@@ -7,6 +7,12 @@ from pathlib import Path
 
 def test_invalid_path(tmp_path):
     (tmp_path / 'whisper.py').write_text('def load_model(name):\n    return None\n')
+    (tmp_path / 'torch.py').write_text(
+        'class cuda:\n'
+        '    @staticmethod\n'
+        '    def is_available():\n'
+        '        return False\n'
+    )
     env = {**os.environ, 'PYTHONPATH': str(tmp_path)}
     script = Path(__file__).with_name('whisper_transcribe.py')
     result = subprocess.run([sys.executable, str(script), 'nonexistent'], capture_output=True, text=True, env=env)
@@ -17,17 +23,26 @@ def test_invalid_path(tmp_path):
 def test_transcribe_directory(tmp_path):
     audio = tmp_path / 'sample.wav'
     audio.write_bytes(b'')
-    stub = (
+    whisper_stub = (
         'from pathlib import Path\n'
+        'fp16_file = Path(__file__).with_name("fp16.txt")\n'
         'class Dummy:\n'
-        '    def transcribe(self, path):\n'
+        '    def transcribe(self, path, fp16=False):\n'
+        '        fp16_file.write_text(str(fp16))\n'
         '        return {"text": Path(path).name}\n'
         'def load_model(name):\n'
         '    return Dummy()\n'
     )
-    (tmp_path / 'whisper.py').write_text(stub)
+    (tmp_path / 'whisper.py').write_text(whisper_stub)
+    (tmp_path / 'torch.py').write_text(
+        'class cuda:\n'
+        '    @staticmethod\n'
+        '    def is_available():\n'
+        '        return False\n'
+    )
     env = {**os.environ, 'PYTHONPATH': str(tmp_path)}
     script = Path(__file__).with_name('whisper_transcribe.py')
     result = subprocess.run([sys.executable, str(script), str(tmp_path)], capture_output=True, text=True, env=env)
     assert result.returncode == 0
     assert 'sample.wav\tsample.wav' in result.stdout
+    assert (tmp_path / 'fp16.txt').read_text() == 'False'

--- a/script/whisper_transcribe.py
+++ b/script/whisper_transcribe.py
@@ -8,10 +8,12 @@ printed one per line in the format ``<path>\t<text>``.
 from pathlib import Path
 import sys
 
+import torch  # type: ignore
+
 
 def _transcribe_file(model: "whisper.Whisper", audio_path: Path) -> str:
     """Return transcription text for ``audio_path`` using ``model``."""
-    result = model.transcribe(str(audio_path))
+    result = model.transcribe(str(audio_path), fp16=torch.cuda.is_available())
     return result.get("text", "").strip()
 
 


### PR DESCRIPTION
## Summary
- select FP32 on CPUs to avoid Whisper FP16 warnings
- cover fp16 behavior in tests
- document precision selection in README

## Testing
- `pytest`
- `php script/test_index.php`


------
https://chatgpt.com/codex/tasks/task_e_689b155f47e88331922c7dbef502aea8