### PR TITLE
Skip existing transcripts during batch conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
 
 - `public_html/index.php` – PHP entry point that calls the Python helper.
 - `script/whisper_transcribe.py` – Python script performing the transcription.
-- `script/convert_all.bat` – Windows helper to batch transcribe `.wav` files.
+- `script/convert_all.bat` – Windows helper to batch transcribe `.wav` files; skips files with an existing non-empty `.txt` transcript.
 - `config_files/config.php` – configuration for paths including the sound directory.
 - `documents/`, `business_information/`, `etc/` – placeholders for project
   organisation.
@@ -41,6 +41,8 @@ individual `.txt` files by running:
 ```bat
 script\convert_all.bat
 ```
+
+Existing non-empty `.txt` files are left untouched.
 
 ## Testing
 

--- a/script/convert_all.bat
+++ b/script/convert_all.bat
@@ -3,4 +3,4 @@ REM convert_all.bat - Transcribe WAV files to TXT using whisper_transcribe.py
 set "BASE=%~1"
 if "%BASE%"=="" set "BASE=C:\wisper\sound"
 if not exist "%BASE%" echo Directory not found: %BASE% & exit /b 1
-for /r "%BASE%" %%F in (*.wav) do python "%~dp0whisper_transcribe.py" "%%F" > "%%~dpnF.txt"
+for /r "%BASE%" %%F in (*.wav) do if exist "%%~dpnF.txt" (for %%Z in ("%%~dpnF.txt") do if %%~zZ gtr 0 (echo Skipping "%%F") else python "%~dp0whisper_transcribe.py" "%%F" > "%%~dpnF.txt") else python "%~dp0whisper_transcribe.py" "%%F" > "%%~dpnF.txt"

--- a/script/test_convert_all_bat.py
+++ b/script/test_convert_all_bat.py
@@ -6,3 +6,5 @@ def test_batch_script_contains_expected_commands():
     bat = Path(__file__).with_name('convert_all.bat').read_text(encoding='utf-8')
     assert 'whisper_transcribe.py' in bat
     assert 'for /r "%BASE%" %%F in (*.wav)' in bat
+    assert 'if exist "%%~dpnF.txt"' in bat
+    assert '%%~zZ gtr 0' in bat


### PR DESCRIPTION
## Summary
- avoid overwriting transcripts by skipping WAV files that already have a non-empty `.txt` companion
- document the skipping behaviour for `convert_all.bat`
- test batch script for new guard conditions

## Testing
- `pytest`
- `php script/test_index.php`


------
https://chatgpt.com/codex/tasks/task_e_689b15c0c2208331b759bbe0e18faed4