### PR TITLE
Add timestamped CRLF transcription output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /sound/*/*/*.wav
-/script/__pycache__/test_whisper_transcribe.cpython-310-pytest-7.3.1.pyc
+script/__pycache__/
 /*.rar
 /sound/*/*/*.txt

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
 
 - `script/convert_all.bat` – Windows helper to batch transcribe `.wav` files; skips files with an existing non-empty `.txt` transcript.
 - `script/whisper_transcribe.py` – Python script performing the transcription. It
-  selects FP16 on GPUs and uses FP32 on CPUs to avoid precision warnings.
+  selects FP16 on GPUs and uses FP32 on CPUs to avoid precision warnings. Each
+  transcript line includes a `[HH:MM:SS]` timestamp and uses Windows style CRLF
+  line endings.
 - `config_files/config.php` – configuration for paths including the sound directory.
 - `documents/`, `business_information/`, `etc/` – placeholders for project
   organisation.
@@ -35,7 +37,8 @@ To transcribe a single file:
 php public_html/index.php path="C:\\wisper\\07\\09\\rg-900-+4550499106-20250709-131344-1752059605.163788.wav"
 ```
 
-The script prints the transcription text to standard output.
+The script prints the transcription text to standard output with timestamps and
+CRLF line endings, making the output Windows friendly.
 
 On Windows you can convert every `.wav` under `C:\\wisper\\sound` to
 individual `.txt` files by running:

--- a/script/test_whisper_transcribe.py
+++ b/script/test_whisper_transcribe.py
@@ -29,7 +29,7 @@ def test_transcribe_directory(tmp_path):
         'class Dummy:\n'
         '    def transcribe(self, path, fp16=False):\n'
         '        fp16_file.write_text(str(fp16))\n'
-        '        return {"text": Path(path).name}\n'
+        '        return {"segments": [{"start": 0.0, "text": Path(path).name}]}\n'
         'def load_model(name):\n'
         '    return Dummy()\n'
     )
@@ -42,7 +42,8 @@ def test_transcribe_directory(tmp_path):
     )
     env = {**os.environ, 'PYTHONPATH': str(tmp_path)}
     script = Path(__file__).with_name('whisper_transcribe.py')
-    result = subprocess.run([sys.executable, str(script), str(tmp_path)], capture_output=True, text=True, env=env)
+    result = subprocess.run([sys.executable, str(script), str(tmp_path)], capture_output=True, env=env)
     assert result.returncode == 0
-    assert 'sample.wav\tsample.wav' in result.stdout
+    expected = f"{audio}\t[00:00:00] sample.wav\r\n".encode()
+    assert result.stdout == expected
     assert (tmp_path / 'fp16.txt').read_text() == 'False'

--- a/script/whisper_transcribe.py
+++ b/script/whisper_transcribe.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
-"""Transcribe audio files using openai-whisper.
+"""Transcribe audio files using openai-whisper with timestamps.
 
 The script accepts either a single audio file or a directory. When a directory
 is supplied all ``.wav`` files within it are transcribed and the results are
-printed one per line in the format ``<path>\t<text>``.
+printed one per line in the format ``<path>\t<text>``. Each transcription line
+includes a ``[HH:MM:SS]`` timestamp and uses CRLF line endings so the output is
+Windows friendly.
 """
 from pathlib import Path
 import sys
@@ -11,9 +13,25 @@ import sys
 import torch  # type: ignore
 
 
+def _format_timestamp(seconds: float) -> str:
+    """Return ``HH:MM:SS`` timestamp for ``seconds``."""
+    seconds_int = int(seconds)
+    minutes, sec = divmod(seconds_int, 60)
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours:02}:{minutes:02}:{sec:02}"
+
+
 def _transcribe_file(model: "whisper.Whisper", audio_path: Path) -> str:
-    """Return transcription text for ``audio_path`` using ``model``."""
+    """Return timestamped transcription text for ``audio_path`` using ``model``."""
     result = model.transcribe(str(audio_path), fp16=torch.cuda.is_available())
+    segments = result.get("segments")
+    if segments:
+        lines = []
+        for segment in segments:
+            ts = _format_timestamp(float(segment.get("start", 0.0)))
+            text = str(segment.get("text", "")).strip()
+            lines.append(f"[{ts}] {text}")
+        return "\r\n".join(lines)
     return result.get("text", "").strip()
 
 
@@ -31,6 +49,7 @@ def main() -> int:
         print(f'Path not found: {target}', file=sys.stderr)
         return 1
     model = whisper.load_model('base')
+    sys.stdout.reconfigure(newline="\r\n")
     if target.is_file():
         print(_transcribe_file(model, target))
     else:


### PR DESCRIPTION
## Summary
- add timestamp formatting and Windows-friendly CRLF output to `whisper_transcribe.py`
- update tests for timestamped output and CRLF line endings
- document timestamped output and CRLF handling in README and ignore Python cache files

## Testing
- `pytest`
- `php script/test_index.php`
- `php script/test_rename_recording.php`


------
https://chatgpt.com/codex/tasks/task_e_689b2bf5364c83319013d8bf407b98c6