### PR TITLE
Add OpenAI Whisper API transcription script

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
 ## Layout
 
 - `public_html/index.php` – PHP entry point that calls the Python helper.
+- `public_html/openai_transcribe.php` – PHP script calling OpenAI's Whisper API.
 
 - `script/convert_all.bat` – Windows helper to batch transcribe `.wav` files; skips files with an existing non-empty `.txt` transcript and produces an empty `.txt` for silent audio.
 - `script/whisper_transcribe.py` – Python script performing the transcription. It
@@ -21,6 +22,7 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
 - Python 3 with `openai-whisper` installed (`pip install -U openai-whisper`).
 - `ffmpeg` available on the system path.
 - PHP 8 running under XAMPP or similar.
+- OpenAI API key in `OPENAI_API_KEY` for API-based transcription.
 
 ## Usage
 
@@ -49,9 +51,16 @@ script\convert_all.bat
 
 Existing non-empty `.txt` files are left untouched.
 
+To transcribe a file using the OpenAI API:
+
+```bash
+OPENAI_API_KEY=your_key php public_html/openai_transcribe.php path/to/audio.wav
+```
+
 ## Testing
 
 ```bash
 pytest
 php script/test_index.php
+php script/test_openai_transcribe.php
 ```

--- a/public_html/openai_transcribe.php
+++ b/public_html/openai_transcribe.php
@@ -1,0 +1,51 @@
+<?php
+// REM Transcribe audio files using the OpenAI Whisper API
+/**
+ * Transcribe the given audio file using OpenAI's Whisper API.
+ */
+function openai_transcribe(string $audioPath): string
+{
+    if (!file_exists($audioPath)) {
+        return 'Error: audio file not found';
+    }
+    $apiKey = getenv('OPENAI_API_KEY');
+    if ($apiKey === false || $apiKey === '') {
+        return 'Error: missing API key';
+    }
+    $ch = curl_init('https://api.openai.com/v1/audio/transcriptions');
+    $cfile = curl_file_create($audioPath, 'audio/wav', basename($audioPath));
+    $data = [
+        'model' => 'whisper-1',
+        'file' => $cfile,
+    ];
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POST => true,
+        CURLOPT_HTTPHEADER => [
+            'Authorization: Bearer ' . $apiKey,
+        ],
+        CURLOPT_POSTFIELDS => $data,
+    ]);
+    $response = curl_exec($ch);
+    if ($response === false) {
+        $error = curl_error($ch);
+        curl_close($ch);
+        return 'Error: ' . $error;
+    }
+    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    $json = json_decode($response, true);
+    if ($status !== 200 || !is_array($json) || !isset($json['text'])) {
+        return 'Error: API request failed';
+    }
+    return (string) $json['text'];
+}
+
+if (realpath(__FILE__) === realpath($_SERVER['SCRIPT_FILENAME'])) {
+    if ($argc !== 2) {
+        fwrite(STDERR, "Usage: php openai_transcribe.php <audio_file>\n");
+        exit(1);
+    }
+    echo openai_transcribe($argv[1]);
+}
+?>

--- a/script/test_openai_transcribe.php
+++ b/script/test_openai_transcribe.php
@@ -1,0 +1,17 @@
+<?php
+require __DIR__ . '/../public_html/openai_transcribe.php';
+
+$result = openai_transcribe('missing.wav');
+if ($result !== 'Error: audio file not found') {
+    fwrite(STDERR, "Unexpected output: $result\n");
+    exit(1);
+}
+
+$result = openai_transcribe(__FILE__);
+if ($result !== 'Error: missing API key') {
+    fwrite(STDERR, "Unexpected output: $result\n");
+    exit(1);
+}
+
+echo "OK\n";
+?>


### PR DESCRIPTION
## Summary
- Add `openai_transcribe.php` to call the OpenAI Whisper API from PHP
- Document API-based transcription workflow and required environment variable
- Provide PHP test covering missing file and missing API key cases

## Testing
- `pytest`
- `php script/test_index.php`
- `php script/test_openai_transcribe.php`


------
https://chatgpt.com/codex/tasks/task_e_689c1ef3d1e88331b55b9a6dece4c917