### PR TITLE
Add audio conversion script with cron usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,26 @@ To transcribe a file using the OpenAI API:
 OPENAI_API_KEY=your_key php public_html/openai_transcribe.php path/to/audio.wav
 ```
 
+### Convert and save a transcript
+
+Use `script/convertThis.php` to create a text transcript next to an audio file:
+
+```bash
+php script/convertThis.php "file:///C:/wisper/sound/07/01/exten-FredericNygaard-unknown-20250701-080009-1751349609.81224.wav"
+```
+
+The script prints debug information and returns the path of the generated
+`*.openai.txt` file. A cron entry can run the conversion automatically:
+
+```cron
+* * * * * cd /path/to/wisperHVDK && php script/convertThis.php "file:///C:/wisper/sound/07/01/example.wav"
+```
+
 ## Testing
 
 ```bash
 pytest
 php script/test_index.php
 php script/test_openai_transcribe.php
+php script/test_convertThis.php
 ```

--- a/script/convertThis.php
+++ b/script/convertThis.php
@@ -1,0 +1,70 @@
+<?php
+// REM Transcribe a single audio recording and save the result to a .openai.txt file
+require __DIR__ . '/../public_html/openai_transcribe.php';
+
+/**
+ * Convert a recording to text using a transcription function.
+ *
+ * @param string   $uri          File path or file:// URI.
+ * @param callable $transcribeFn Function that accepts the file path and returns the text.
+ * @param bool     $debug        Whether to print debug output.
+ *
+ * @return string                Output path of the transcript or an error message.
+ */
+function convert_recording(string $uri, $transcribeFn = 'openai_transcribe', bool $debug = false): string
+{
+    if ($debug) {
+        echo "Debug: input $uri\n";
+    }
+    $path = $uri;
+    if (strpos($uri, 'file://') === 0) {
+        $path = substr($uri, 7);
+        if (PHP_OS_FAMILY === 'Windows' && isset($path[0]) && $path[0] === '/') {
+            $path = ltrim($path, '/');
+        }
+        if ($debug) {
+            echo "Debug: parsed file URI to $path\n";
+        }
+    }
+    if (!file_exists($path)) {
+        if ($debug) {
+            echo "Debug: file not found\n";
+        }
+        return 'Error: file not found';
+    }
+    $text = $transcribeFn($path);
+    if (strpos($text, 'Error:') === 0) {
+        if ($debug) {
+            echo "Debug: transcription failed\n";
+        }
+        return $text;
+    }
+    $dir = dirname($path);
+    $base = pathinfo($path, PATHINFO_FILENAME);
+    $timestamp = date('Ymd-His');
+    $id = sprintf('%.5f', microtime(true));
+    $parts = explode('-', $base);
+    if (count($parts) >= 5) {
+        $parts[count($parts) - 2] = $timestamp;
+        $parts[count($parts) - 1] = $id;
+        $base = implode('-', $parts);
+    } else {
+        $base .= '-' . $timestamp . '-' . $id;
+    }
+    $outPath = $dir . DIRECTORY_SEPARATOR . $base . '.openai.txt';
+    if ($debug) {
+        echo "Debug: writing transcript to $outPath\n";
+    }
+    file_put_contents($outPath, $text);
+    return $outPath;
+}
+
+if (realpath(__FILE__) === realpath($_SERVER['SCRIPT_FILENAME'])) {
+    $uri = $argv[1] ?? '';
+    if ($uri === '') {
+        fwrite(STDERR, "Usage: php convertThis.php <file_uri>\n");
+        exit(1);
+    }
+    echo convert_recording($uri, 'openai_transcribe', true);
+}
+?>

--- a/script/test_convertThis.php
+++ b/script/test_convertThis.php
@@ -1,0 +1,38 @@
+<?php
+require __DIR__ . '/convertThis.php';
+
+function stub_transcribe(string $path): string
+{
+    return 'Transcribed text';
+}
+
+$dir = __DIR__ . '/../sound/07/01';
+if (!is_dir($dir)) {
+    mkdir($dir, 0777, true);
+}
+$wav = $dir . '/exten-TestUser-unknown-20250701-080009-1751349609.81224.wav';
+file_put_contents($wav, '');
+
+// Error for missing file
+$result = convert_recording($wav . '.missing', 'stub_transcribe');
+if ($result !== 'Error: file not found') {
+    fwrite(STDERR, "Unexpected error handling: $result\n");
+    unlink($wav);
+    exit(1);
+}
+
+// Success with file URI
+$uri = 'file:///' . str_replace('\\', '/', $wav);
+$outPath = convert_recording($uri, 'stub_transcribe');
+if (!file_exists($outPath) || trim(file_get_contents($outPath)) !== 'Transcribed text') {
+    fwrite(STDERR, "Unexpected output\n");
+    unlink($wav);
+    if (file_exists($outPath)) { unlink($outPath); }
+    exit(1);
+}
+
+unlink($wav);
+unlink($outPath);
+
+echo "OK\n";
+?>


### PR DESCRIPTION
## Summary
- add `script/convertThis.php` for converting WAV recordings to `.openai.txt` transcripts
- document cron usage and new conversion workflow in README
- cover conversion logic with `script/test_convertThis.php`

## Testing
- `pytest`
- `php script/test_index.php`
- `php script/test_openai_transcribe.php`
- `php script/test_rename_recording.php`
- `php script/test_convertThis.php`


------
https://chatgpt.com/codex/tasks/task_e_689c267dcda88331a4989292cd5abd6b