### PR TITLE
Add timestamped transcripts and simple filename conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
 ## Layout
 
 - `public_html/index.php` – PHP entry point that calls the Python helper.
-- `public_html/openai_transcribe.php` – PHP script calling OpenAI's Whisper API.
+- `public_html/openai_transcribe.php` – PHP script calling OpenAI's Whisper API and
+  returning a timestamped transcript with CRLF line endings.
 
 - `script/convert_all.bat` – Windows helper to batch transcribe `.wav` files; skips files with an existing non-empty `.txt` transcript and produces an empty `.txt` for silent audio.
 - `script/whisper_transcribe.py` – Python script performing the transcription. It
@@ -59,7 +60,8 @@ OPENAI_API_KEY=your_key php public_html/openai_transcribe.php path/to/audio.wav
 
 ### Convert and save a transcript
 
-Use `script/convertThis.php` to create a text transcript next to an audio file:
+Use `script/convertThis.php` to create a text transcript next to an audio file.
+The `.wav` extension is replaced with `.openai.txt`:
 
 ```bash
 php script/convertThis.php "file:///C:/wisper/sound/07/01/exten-FredericNygaard-unknown-20250701-080009-1751349609.81224.wav"

--- a/script/convertThis.php
+++ b/script/convertThis.php
@@ -21,6 +21,8 @@ function convert_recording(string $uri, $transcribeFn = 'openai_transcribe', boo
         $path = substr($uri, 7);
         if (PHP_OS_FAMILY === 'Windows' && isset($path[0]) && $path[0] === '/') {
             $path = ltrim($path, '/');
+        } else {
+            $path = '/' . ltrim($path, '/');
         }
         if ($debug) {
             echo "Debug: parsed file URI to $path\n";
@@ -39,19 +41,12 @@ function convert_recording(string $uri, $transcribeFn = 'openai_transcribe', boo
         }
         return $text;
     }
-    $dir = dirname($path);
-    $base = pathinfo($path, PATHINFO_FILENAME);
-    $timestamp = date('Ymd-His');
-    $id = sprintf('%.5f', microtime(true));
-    $parts = explode('-', $base);
-    if (count($parts) >= 5) {
-        $parts[count($parts) - 2] = $timestamp;
-        $parts[count($parts) - 1] = $id;
-        $base = implode('-', $parts);
-    } else {
-        $base .= '-' . $timestamp . '-' . $id;
+    $outPath = preg_replace('/\.wav$/i', '.openai.txt', $path);
+    if ($outPath === null) {
+        $dir = dirname($path);
+        $base = pathinfo($path, PATHINFO_FILENAME);
+        $outPath = $dir . DIRECTORY_SEPARATOR . $base . '.openai.txt';
     }
-    $outPath = $dir . DIRECTORY_SEPARATOR . $base . '.openai.txt';
     if ($debug) {
         echo "Debug: writing transcript to $outPath\n";
     }

--- a/script/test_convertThis.php
+++ b/script/test_convertThis.php
@@ -24,7 +24,7 @@ if ($result !== 'Error: file not found') {
 // Success with file URI
 $uri = 'file:///' . str_replace('\\', '/', $wav);
 $outPath = convert_recording($uri, 'stub_transcribe');
-if (!file_exists($outPath) || trim(file_get_contents($outPath)) !== 'Transcribed text') {
+if ($outPath !== preg_replace('/\.wav$/', '.openai.txt', $wav) || !file_exists($outPath) || trim(file_get_contents($outPath)) !== 'Transcribed text') {
     fwrite(STDERR, "Unexpected output\n");
     unlink($wav);
     if (file_exists($outPath)) { unlink($outPath); }

--- a/script/test_openai_transcribe.php
+++ b/script/test_openai_transcribe.php
@@ -13,5 +13,15 @@ if ($result !== 'Error: missing API key') {
     exit(1);
 }
 
+$segments = [
+    ['start' => 0.0, 'text' => 'Hello'],
+    ['start' => 4.2, 'text' => 'Hi again'],
+];
+$expected = "[00:00:00] Hello\r\n[00:00:04] Hi again";
+if (format_transcript_segments($segments) !== $expected) {
+    fwrite(STDERR, "Unexpected formatting\n");
+    exit(1);
+}
+
 echo "OK\n";
 ?>


### PR DESCRIPTION
## Summary
- Format OpenAI transcript segments with `[HH:MM:SS]` timestamps and CRLF endings
- Replace `.wav` with `.openai.txt` when saving transcripts and normalize `file://` URIs
- Document new behavior and add unit tests for segment formatting and conversion

## Testing
- `pytest`
- `php script/test_index.php`
- `php script/test_openai_transcribe.php`
- `php script/test_convertThis.php`
- `php script/test_rename_recording.php`


------
https://chatgpt.com/codex/tasks/task_e_689c363925d083318fc13bb4082dd6dd