### PR TITLE
Add script to remove short WAV files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
   selects FP16 on GPUs and uses FP32 on CPUs to avoid precision warnings. Each
   transcript line includes a `[HH:MM:SS]` timestamp, emits UTF-8 text and uses
   Windows style CRLF line endings.
+- `script/delete_short_files.php` – removes `.wav` files shorter than one minute.
 - `config_files/config.php` – configuration for paths including the sound directory.
 - `documents/`, `business_information/`, `etc/` – placeholders for project
   organisation.
@@ -72,6 +73,12 @@ The script prints debug information and returns the path of the generated
 
 ```cron
 * * * * * cd /path/to/wisperHVDK && php script/convertThis.php "file:///C:/wisper/sound/07/01/example.wav"
+```
+
+To delete `.wav` files shorter than one minute within a directory (default is `sound`):
+
+```bash
+php script/delete_short_files.php /path/to/dir
 ```
 
 ## Testing

--- a/public_html/delete_short_files.php
+++ b/public_html/delete_short_files.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Delete WAV audio files shorter than one minute.
+ *
+ * Usage: php delete_short_files.php [directory]
+ */
+function getWavDuration(string $file): ?float
+{
+    $handle = fopen($file, 'rb');
+    if ($handle === false) {
+        return null;
+    }
+
+    fseek($handle, 22);
+    $channels = unpack('v', fread($handle, 2))[1];
+
+    $sampleRate = unpack('V', fread($handle, 4))[1];
+
+    fseek($handle, 34);
+    $bitsPerSample = unpack('v', fread($handle, 2))[1];
+
+    fseek($handle, 40);
+    $dataSize = unpack('V', fread($handle, 4))[1];
+    fclose($handle);
+
+    if ($channels === 0 || $bitsPerSample === 0 || $sampleRate === 0) {
+        return null;
+    }
+
+    $bytesPerSample = ($bitsPerSample / 8) * $channels;
+    return $dataSize / ($sampleRate * $bytesPerSample);
+}
+
+$directory = $argv[1] ?? __DIR__ . '/../sound';
+$directory = rtrim($directory, DIRECTORY_SEPARATOR);
+
+if (!is_dir($directory)) {
+    fwrite(STDERR, "Directory not found: {$directory}" . PHP_EOL);
+    exit(1);
+}
+
+$files = glob($directory . '/*.{wav}', GLOB_BRACE);
+foreach ($files as $file) {
+    $duration = getWavDuration($file);
+    if ($duration !== null && $duration < 60) {
+        unlink($file);
+        echo 'Deleted ' . basename($file) . PHP_EOL;
+    }
+}

--- a/script/delete_short_files.php
+++ b/script/delete_short_files.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Delete WAV audio files shorter than one minute.
+ *
+ * Usage: php delete_short_files.php [directory]
+ */
+function getWavDuration(string $file): ?float
+{
+    $handle = fopen($file, 'rb');
+    if ($handle === false) {
+        return null;
+    }
+
+    fseek($handle, 22);
+    $channels = unpack('v', fread($handle, 2))[1];
+
+    $sampleRate = unpack('V', fread($handle, 4))[1];
+
+    fseek($handle, 34);
+    $bitsPerSample = unpack('v', fread($handle, 2))[1];
+
+    fseek($handle, 40);
+    $dataSize = unpack('V', fread($handle, 4))[1];
+    fclose($handle);
+
+    if ($channels === 0 || $bitsPerSample === 0 || $sampleRate === 0) {
+        return null;
+    }
+
+    $bytesPerSample = ($bitsPerSample / 8) * $channels;
+    return $dataSize / ($sampleRate * $bytesPerSample);
+}
+
+$directory = $argv[1] ?? __DIR__ . '/../sound';
+$directory = rtrim($directory, DIRECTORY_SEPARATOR);
+
+if (!is_dir($directory)) {
+    fwrite(STDERR, "Directory not found: {$directory}" . PHP_EOL);
+    exit(1);
+}
+
+$files = glob($directory . '/*.{wav}', GLOB_BRACE);
+foreach ($files as $file) {
+    $duration = getWavDuration($file);
+    if ($duration !== null && $duration < 60) {
+        unlink($file);
+        echo 'Deleted ' . basename($file) . PHP_EOL;
+    }
+}

--- a/script/tests/test_delete_short_files.py
+++ b/script/tests/test_delete_short_files.py
@@ -1,0 +1,28 @@
+import os
+import subprocess
+import tempfile
+import wave
+
+
+def create_wave(path: str, duration: int, sample_rate: int = 8000) -> None:
+    frames = duration * sample_rate
+    with wave.open(path, "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(1)
+        wf.setframerate(sample_rate)
+        wf.writeframes(b"\x00" * frames)
+
+
+def test_delete_short_files() -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        short = os.path.join(tmpdir, "short.wav")
+        long = os.path.join(tmpdir, "long.wav")
+        create_wave(short, 30)
+        create_wave(long, 61)
+        subprocess.run([
+            "php",
+            os.path.join("script", "delete_short_files.php"),
+            tmpdir,
+        ], check=True)
+        assert not os.path.exists(short)
+        assert os.path.exists(long)


### PR DESCRIPTION
## Summary
- add PHP helper that deletes WAV files shorter than one minute
- document file cleanup helper in README
- test short-file deletion logic with generated sample audio

## Testing
- `pytest script/tests/test_delete_short_files.py -q`
- `pytest -q`
- `php script/test_index.php`
- `php script/test_openai_transcribe.php`
- `php script/test_convertThis.php`
- `php script/test_rename_recording.php`
- `python script/test_convert_all_bat.py`
- `php -l script/delete_short_files.php`
- `php -l public_html/delete_short_files.php`


------
https://chatgpt.com/codex/tasks/task_e_689c3ec184f4833186dfa89e67d1fd66