### PR TITLE
Expand recording rename to use contact names

### DIFF
--- a/script/test_rename_recording.php
+++ b/script/test_rename_recording.php
@@ -7,43 +7,53 @@ $dir2 = $base . '/07/03';
 if (!is_dir($dir1)) { mkdir($dir1, 0777, true); }
 if (!is_dir($dir2)) { mkdir($dir2, 0777, true); }
 
-$old1 = $dir1 . '/exten-1183-unknown-20250701-111155-1751361115.85474';
-$new1 = $dir1 . '/exten-SuneKidmose-unknown-20250701-111155-1751361115.85474';
-$old2 = $dir2 . '/exten-1183-unknown-20250701-111155-1751361115.85475';
-$new2 = $dir2 . '/exten-SuneKidmose-unknown-20250701-111155-1751361115.85475';
+$old1 = $dir1 . '/out-25787816-1183-20250701-111155-1751361115.85474.wav';
+$new1 = $dir1 . '/out-25787816-SuneKidmose-Salgs-20250701-111155-1751361115.85474.wav';
+$old2 = $dir2 . '/out-25787816-1183-20250701-111155-1751361115.85475.wav';
+$new2 = $dir2 . '/out-25787816-SuneKidmose-Salgs-20250701-111155-1751361115.85475.wav';
+$old3 = $dir1 . '/exten-8504-unknown-20250701-111155-1751361115.85476.wav';
+$new3 = $dir1 . '/exten-MortenHyldgaard-CS-unknown-20250701-111155-1751361115.85476.wav';
 file_put_contents($old1, '');
 file_put_contents($old2, '');
+file_put_contents($old3, '');
 
 $results = rename_recordings($base);
-if ($results[$old1] !== $new1 || !file_exists($new1) || $results[$old2] !== $new2 || !file_exists($new2)) {
+if ($results[$old1] !== $new1 || !file_exists($new1) || $results[$old2] !== $new2 || !file_exists($new2) || $results[$old3] !== $new3 || !file_exists($new3)) {
     fwrite(STDERR, "Unexpected output\n");
     if (file_exists($old1)) { unlink($old1); }
     if (file_exists($new1)) { unlink($new1); }
     if (file_exists($old2)) { unlink($old2); }
     if (file_exists($new2)) { unlink($new2); }
+    if (file_exists($old3)) { unlink($old3); }
+    if (file_exists($new3)) { unlink($new3); }
     exit(1);
 }
 
 unlink($new1);
 unlink($new2);
+unlink($new3);
 
 // Test with debug enabled and capture output
 file_put_contents($old1, '');
 file_put_contents($old2, '');
+file_put_contents($old3, '');
 ob_start();
 $results = rename_recordings($base, __DIR__ . '/../contacts.csv', true);
 $debug = ob_get_clean();
-if ($results[$old1] !== $new1 || !file_exists($new1) || $results[$old2] !== $new2 || !file_exists($new2) || strpos($debug, 'Debug:') === false) {
+if ($results[$old1] !== $new1 || !file_exists($new1) || $results[$old2] !== $new2 || !file_exists($new2) || $results[$old3] !== $new3 || !file_exists($new3) || strpos($debug, 'Debug:') === false) {
     fwrite(STDERR, "Unexpected debug output\n");
     if (file_exists($old1)) { unlink($old1); }
     if (file_exists($new1)) { unlink($new1); }
     if (file_exists($old2)) { unlink($old2); }
     if (file_exists($new2)) { unlink($new2); }
+    if (file_exists($old3)) { unlink($old3); }
+    if (file_exists($new3)) { unlink($new3); }
     exit(1);
 }
 
 unlink($new1);
 unlink($new2);
+unlink($new3);
 
 echo "OK\n";
 ?>


### PR DESCRIPTION
## Summary
- handle `exten-<extension>` and `out-*-<extension>` recordings when replacing extension numbers with contact names
- test renaming logic for both patterns

## Testing
- `php script/test_rename_recording.php`


------
https://chatgpt.com/codex/tasks/task_e_689c404bec10833188a30f2bae730172