### PR TITLE
Add Whisper transcription cost calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
   transcript line includes a `[HH:MM:SS]` timestamp, emits UTF-8 text and uses
   Windows style CRLF line endings.
 - `script/delete_short_files.php` – removes `.wav` files shorter than one minute.
+- `script/whisper_cost.php` – estimates the cost of transcribing `.wav` files
+  using Whisper's pricing (`$0.006` per minute).
 - `config_files/config.php` – configuration for paths including the sound directory.
 - `documents/`, `business_information/`, `etc/` – placeholders for project
   organisation.
@@ -88,4 +90,5 @@ pytest
 php script/test_index.php
 php script/test_openai_transcribe.php
 php script/test_convertThis.php
+php script/test_whisper_cost.php
 ```

--- a/script/test_whisper_cost.php
+++ b/script/test_whisper_cost.php
@@ -1,0 +1,73 @@
+<?php
+
+function create_wav(string $path, int $seconds, int $rate = 8000): void {
+    $numChannels = 1;
+    $bitsPerSample = 16;
+    $blockAlign = $numChannels * $bitsPerSample / 8;
+    $byteRate = $rate * $blockAlign;
+    $numSamples = $rate * $seconds;
+    $dataSize = $numSamples * $blockAlign;
+    $chunkSize = 36 + $dataSize;
+    $h = fopen($path, 'wb');
+    fwrite($h, 'RIFF');
+    fwrite($h, pack('V', $chunkSize));
+    fwrite($h, 'WAVEfmt ');
+    fwrite($h, pack('VvvVVvv', 16, 1, $numChannels, $rate, $byteRate, $blockAlign, $bitsPerSample));
+    fwrite($h, 'data');
+    fwrite($h, pack('V', $dataSize));
+    fwrite($h, str_repeat(pack('v', 0), $numSamples));
+    fclose($h);
+}
+
+function run_cmd(string $cmd, ?string &$stderr = null): array {
+    $proc = proc_open($cmd, [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => ['pipe', 'w']], $pipes);
+    if (!is_resource($proc)) {
+        throw new RuntimeException('Failed to execute command');
+    }
+    fclose($pipes[0]);
+    $stdout = stream_get_contents($pipes[1]);
+    fclose($pipes[1]);
+    $stderrContent = stream_get_contents($pipes[2]);
+    fclose($pipes[2]);
+    $code = proc_close($proc);
+    $stderr = $stderrContent;
+    return [$code, $stdout];
+}
+
+$script = __DIR__ . '/whisper_cost.php';
+$tmpdir = sys_get_temp_dir() . '/whisper_cost_' . uniqid();
+mkdir($tmpdir);
+
+create_wav($tmpdir . '/a.wav', 6);
+create_wav($tmpdir . '/b.wav', 3);
+[$code, $out] = run_cmd('php ' . escapeshellarg($script) . ' ' . escapeshellarg($tmpdir));
+if ($code !== 0 || strpos($out, $tmpdir . "/a.wav\t$0.0006") === false || strpos($out, $tmpdir . "/b.wav\t$0.0003") === false || strpos($out, "Total\t$0.0009") === false) {
+    fwrite(STDERR, "Directory test failed\n");
+    array_map('unlink', glob($tmpdir . '/*.wav'));
+    rmdir($tmpdir);
+    exit(1);
+}
+
+$single = $tmpdir . '/single.wav';
+create_wav($single, 60);
+[$code, $out] = run_cmd('php ' . escapeshellarg($script) . ' ' . escapeshellarg($single));
+if ($code !== 0 || strpos($out, $single . "\t$0.0060") === false || strpos($out, "Total\t$0.0060") === false) {
+    fwrite(STDERR, "Single file test failed\n");
+    array_map('unlink', glob($tmpdir . '/*.wav'));
+    rmdir($tmpdir);
+    exit(1);
+}
+
+[$code, $out] = run_cmd('php ' . escapeshellarg($script) . ' ' . escapeshellarg($tmpdir . '/missing'), $err);
+if ($code === 0 || strpos($err, 'Path not found') === false) {
+    fwrite(STDERR, "Missing path test failed\n");
+    array_map('unlink', glob($tmpdir . '/*.wav'));
+    rmdir($tmpdir);
+    exit(1);
+}
+
+array_map('unlink', glob($tmpdir . '/*.wav'));
+rmdir($tmpdir);
+
+echo "OK\n";
+?>

--- a/script/whisper_cost.php
+++ b/script/whisper_cost.php
@@ -1,0 +1,51 @@
+<?php
+// Calculate transcription cost for audio files using Whisper pricing.
+// Usage: php whisper_cost.php <audio_file_or_dir>
+
+const RATE_PER_MINUTE = 0.006;
+
+function wav_duration_seconds(string $path): float {
+    $header = @file_get_contents($path, false, null, 0, 44);
+    if ($header === false || strlen($header) < 44) {
+        throw new RuntimeException("Invalid WAV file: $path");
+    }
+    $sampleRate = unpack('V', substr($header, 24, 4))[1];
+    $numChannels = unpack('v', substr($header, 22, 2))[1];
+    $bitsPerSample = unpack('v', substr($header, 34, 2))[1];
+    $dataSize = unpack('V', substr($header, 40, 4))[1];
+    $byteRate = $sampleRate * $numChannels * $bitsPerSample / 8;
+    return $dataSize / $byteRate;
+}
+
+function iter_wav_files(string $target): Generator {
+    if (is_file($target)) {
+        if (strtolower(pathinfo($target, PATHINFO_EXTENSION)) === 'wav') {
+            yield $target;
+        }
+        return;
+    }
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($target));
+    foreach ($iterator as $file) {
+        if ($file->isFile() && strtolower($file->getExtension()) === 'wav') {
+            yield $file->getPathname();
+        }
+    }
+}
+
+if ($argc !== 2) {
+    fwrite(STDERR, "Usage: whisper_cost.php <audio_file_or_dir>\n");
+    exit(1);
+}
+$target = $argv[1];
+if (!file_exists($target)) {
+    fwrite(STDERR, "Path not found: $target\n");
+    exit(1);
+}
+$total = 0.0;
+foreach (iter_wav_files($target) as $wav) {
+    $duration = wav_duration_seconds($wav);
+    $cost = ($duration / 60.0) * RATE_PER_MINUTE;
+    $total += $cost;
+    echo $wav . "\t$" . number_format($cost, 4, '.', '') . PHP_EOL;
+}
+echo "Total\t$" . number_format($total, 4, '.', '') . PHP_EOL;


### PR DESCRIPTION
## Summary
- replace Python cost calculator with `whisper_cost.php`
- add PHP test verifying cost estimates for directories, single files and missing paths
- document new PHP script and update testing instructions

## Testing
- `pytest`
- `php script/test_index.php`
- `php script/test_openai_transcribe.php`
- `php script/test_convertThis.php`
- `php script/test_whisper_cost.php`


------
https://chatgpt.com/codex/tasks/task_e_689c4d75609c8331b1b2d83d684ea3a9