### PR TITLE
Add sound file import script and fix deletion threshold

### DIFF
--- a/script/delete_short_files.php
+++ b/script/delete_short_files.php
@@ -60,10 +60,9 @@ foreach ($iterator as $file) {
         $filePath = $file->getPathname();
         $duration = getWavDuration($filePath);
 
-        if ($duration !== null && $duration < 120) {
-            // Uncomment to actually delete
+        if ($duration !== null && $duration < 60) {
             unlink($filePath);
-            echo 'Deleted .. '.$filePath . $file->getFilename() . ' (' . round($duration, 2) . ' sec)' . PHP_EOL;
+            echo 'Deleted .. ' . $filePath . ' (' . round($duration, 2) . ' sec)' . PHP_EOL;
         }
     }
 }

--- a/script/insert_sound_files.php
+++ b/script/insert_sound_files.php
@@ -1,0 +1,74 @@
+<?php
+// insert_sound_files.php
+// Recursively scan a directory for files and insert each path into sales_call_ratings table.
+
+$directory = $argv[1] ?? 'C:\\wisper\\sound';
+
+if (!is_dir($directory)) {
+    fwrite(STDERR, "Directory not found: {$directory}\n");
+    exit(1);
+}
+
+ $connection = getenv('DB_CONNECTION') ?: 'mysql';
+ $database   = getenv('DB_DATABASE')   ?: 'salescallsanalyse';
+ $username   = getenv('DB_USERNAME')   ?: 'root';
+ $password   = getenv('DB_PASSWORD')   ?: '';
+ $host       = getenv('DB_HOST')       ?: '127.0.0.1';
+
+ if ($connection === 'sqlite') {
+     $dsn = "sqlite:" . $database;
+     $username = null;
+     $password = null;
+ } else {
+     $dsn = "mysql:host={$host};dbname={$database};charset=utf8mb4";
+ }
+
+ try {
+     $pdo = new PDO($dsn, $username, $password, [
+         PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+     ]);
+} catch (PDOException $e) {
+    fwrite(STDERR, "Database connection failed: " . $e->getMessage() . "\n");
+    exit(1);
+}
+
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS)
+);
+
+$sql = "INSERT INTO sales_call_ratings (
+    filepath,
+    call_id,
+    greeting_quality,
+    needs_assessment,
+    product_knowledge,
+    persuasion,
+    closing
+) VALUES (
+    :filepath,
+    :call_id,
+    0,
+    0,
+    0,
+    0,
+    0
+)";
+
+$stmt = $pdo->prepare($sql);
+
+foreach ($iterator as $file) {
+    if (!$file->isFile()) {
+        continue;
+    }
+    $path = $file->getPathname();
+    $callId = pathinfo($path, PATHINFO_FILENAME);
+    try {
+        $stmt->execute([
+            ':filepath' => $path,
+            ':call_id' => $callId,
+        ]);
+    } catch (PDOException $e) {
+        // Continue on duplicate or other insertion errors.
+        fwrite(STDERR, "Failed to insert {$path}: " . $e->getMessage() . "\n");
+    }
+}

--- a/script/tests/test_insert_sound_files.py
+++ b/script/tests/test_insert_sound_files.py
@@ -1,0 +1,62 @@
+import os
+import sqlite3
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def create_file(path: Path) -> None:
+    path.write_bytes(b"test")
+
+
+def test_insert_sound_files(tmp_path: Path) -> None:
+    # Create nested files
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    file1 = tmp_path / "a.txt"
+    file2 = sub / "b.txt"
+    create_file(file1)
+    create_file(file2)
+
+    # Set up SQLite database
+    db_file = tmp_path / "db.sqlite"
+    conn = sqlite3.connect(db_file)
+    conn.execute(
+        """
+        CREATE TABLE sales_call_ratings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            filepath TEXT,
+            WisperTALK TEXT,
+            call_id TEXT NOT NULL,
+            greeting_quality INTEGER NOT NULL,
+            needs_assessment INTEGER NOT NULL,
+            product_knowledge INTEGER NOT NULL,
+            persuasion INTEGER NOT NULL,
+            closing INTEGER NOT NULL,
+            manager_comment TEXT,
+            created_at TEXT DEFAULT CURRENT_TIMESTAMP
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    env = os.environ.copy()
+    env.update({
+        "DB_CONNECTION": "sqlite",
+        "DB_DATABASE": str(db_file),
+    })
+
+    subprocess.run([
+        "php",
+        os.path.join("script", "insert_sound_files.php"),
+        str(tmp_path),
+    ], check=True, env=env)
+
+    conn = sqlite3.connect(db_file)
+    rows = conn.execute("SELECT filepath FROM sales_call_ratings ORDER BY filepath").fetchall()
+    conn.close()
+
+    inserted = [row[0] for row in rows]
+    assert str(file1) in inserted
+    assert str(file2) in inserted


### PR DESCRIPTION
## Summary
- add PHP script to crawl sound directories and insert file paths into `sales_call_ratings`
- cover directory import with SQLite-backed test
- fix WAV cleanup script to remove only files under 60 seconds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c603217708331be00d88fa85e0e6b