### PR TITLE
Add sales call rating database schema using MySQL

### DIFF
--- a/documents/sales_call_ratings.sql
+++ b/documents/sales_call_ratings.sql
@@ -1,0 +1,11 @@
+CREATE TABLE sales_call_ratings (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    call_id VARCHAR(50) NOT NULL,
+    greeting_quality TINYINT UNSIGNED NOT NULL,
+    needs_assessment TINYINT UNSIGNED NOT NULL,
+    product_knowledge TINYINT UNSIGNED NOT NULL,
+    persuasion TINYINT UNSIGNED NOT NULL,
+    closing TINYINT UNSIGNED NOT NULL,
+    manager_comment TEXT,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/script/init_sales_rating_db.php
+++ b/script/init_sales_rating_db.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * Initialize the sales call rating table in a MySQL database.
+ */
+function initSalesRatingDb(PDO $pdo): void
+{
+    $pdo->exec(
+        'CREATE TABLE IF NOT EXISTS sales_call_ratings (
+            id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            call_id VARCHAR(50) NOT NULL,
+            greeting_quality TINYINT UNSIGNED NOT NULL,
+            needs_assessment TINYINT UNSIGNED NOT NULL,
+            product_knowledge TINYINT UNSIGNED NOT NULL,
+            persuasion TINYINT UNSIGNED NOT NULL,
+            closing TINYINT UNSIGNED NOT NULL,
+            manager_comment TEXT,
+            created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4'
+    );
+}
+
+if (PHP_SAPI === 'cli' && realpath($argv[0]) === __FILE__) {
+    $host = getenv('DB_HOST') ?: 'localhost';
+    $db   = getenv('DB_NAME') ?: 'test';
+    $user = getenv('DB_USER') ?: 'root';
+    $pass = getenv('DB_PASS') ?: '';
+    $dsn = "mysql:host={$host};dbname={$db};charset=utf8mb4";
+
+    $pdo = new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
+
+    initSalesRatingDb($pdo);
+    echo "sales_call_ratings table initialized in {$db}\n";
+}

--- a/script/test_sales_rating_db.php
+++ b/script/test_sales_rating_db.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+require __DIR__ . '/init_sales_rating_db.php';
+
+$host = getenv('DB_HOST') ?: 'localhost';
+$db   = getenv('DB_NAME') ?: 'test';
+$user = getenv('DB_USER') ?: 'root';
+$pass = getenv('DB_PASS') ?: '';
+$dsn = "mysql:host={$host};dbname={$db};charset=utf8mb4";
+
+try {
+    $pdo = new PDO($dsn, $user, $pass, [
+        PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+    ]);
+} catch (PDOException $e) {
+    fwrite(STDERR, $e->getMessage() . "\n");
+    exit(1);
+}
+
+$pdo->exec('DROP TABLE IF EXISTS sales_call_ratings');
+initSalesRatingDb($pdo);
+
+$stmt = $pdo->query("SHOW TABLES LIKE 'sales_call_ratings'");
+$row = $stmt->fetch(PDO::FETCH_NUM);
+
+if ($row === false) {
+    echo "sales_call_ratings table missing\n";
+    exit(1);
+}
+
+echo "sales_call_ratings table exists\n";
+$pdo->exec('DROP TABLE sales_call_ratings');
+$pdo = null;


### PR DESCRIPTION
## Summary
- switch sales call rating schema to MySQL with explicit types and autoincrement primary key
- update PHP initialization helper to create table in MySQL using env credentials
- revise unit test to target MySQL table creation

## Testing
- `pytest` *(fails: AssertionError in test_delete_short_files)*
- `php script/test_index.php`
- `php script/test_openai_transcribe.php`
- `php script/test_convertThis.php`
- `php script/test_whisper_cost.php` *(fails: Directory test failed)*
- `php script/test_sales_rating_db.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689c5a30d96c8331b507481c8f7a359e