### PR TITLE
Fix Responses API payload structure

### DIFF
--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -1,0 +1,15 @@
+<?php
+require_once __DIR__ . '/../../public_html/openai_evaluate.php';
+
+$payload = openai_build_payload('sample transcript');
+
+if (($payload['text']['format']['name'] ?? '') !== 'sales_call_evaluation') {
+    fwrite(STDERR, "Missing or incorrect format name\n");
+    exit(1);
+}
+
+$schema = $payload['text']['format']['schema'] ?? null;
+if (!is_array($schema) || !isset($schema['properties']['greeting_quality'])) {
+    fwrite(STDERR, "Schema not structured as expected\n");
+    exit(1);
+}

--- a/script/tests/test_openai_payload.py
+++ b/script/tests/test_openai_payload.py
@@ -1,0 +1,8 @@
+import os
+import subprocess
+
+def test_openai_payload() -> None:
+    subprocess.run([
+        "php",
+        os.path.join("script", "tests", "test_openai_payload.php"),
+    ], check=True)


### PR DESCRIPTION
## Summary
- Build Responses API payload with required `name` field
- Add tests ensuring payload contains schema metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c9e5920648331bcc29a6e133815e1