### PR TITLE
Disallow extra properties in OpenAI schema

### DIFF
--- a/public_html/openai_evaluate.php
+++ b/public_html/openai_evaluate.php
@@ -11,6 +11,7 @@ function openai_build_payload(string $transcript): array
 {
     $schema = [
         'type' => 'object',
+        'additionalProperties' => false,
         'properties' => [
             'greeting_quality' => ['type' => 'integer'],
             'needs_assessment' => ['type' => 'integer'],

--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -13,3 +13,8 @@ if (!is_array($schema) || !isset($schema['properties']['greeting_quality'])) {
     fwrite(STDERR, "Schema not structured as expected\n");
     exit(1);
 }
+
+if (($schema['additionalProperties'] ?? null) !== false) {
+    fwrite(STDERR, "additionalProperties must be false\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- Mark OpenAI evaluation schema with `additionalProperties: false`
- Verify schema integrity via PHP unit test

## Testing
- `php script/tests/test_openai_payload.php`
- `python script/tests/test_openai_payload.py`
- `php script/tests/test_fill_call_ratings.php`
- `python script/tests/test_fill_call_ratings.py`
- `php script/tests/test_fill_wispertalk.php`
- `python script/tests/test_fill_wispertalk.py`
- `python script/tests/test_insert_sound_files.py`


------
https://chatgpt.com/codex/tasks/task_e_689ca364f97883318af410657eed4029