### PR TITLE
Handle nested OpenAI response text

### DIFF
--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -18,3 +18,20 @@ if (($schema['additionalProperties'] ?? null) !== false) {
     fwrite(STDERR, "additionalProperties must be false\n");
     exit(1);
 }
+
+$response = [
+    'output' => [
+        [
+            'type' => 'message',
+            'content' => [
+                ['type' => 'output_text', 'text' => '{"foo":1}'],
+            ],
+        ],
+    ],
+];
+
+$text = openai_extract_output_text($response);
+if ($text !== '{"foo":1}') {
+    fwrite(STDERR, "Failed to extract output text\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- add helper to extract `output_text` from Responses API payloads
- use helper in `openai_evaluate` to handle nested output arrays
- test payload builder and text extraction

## Testing
- `pytest`
- `php script/tests/test_openai_payload.php`
- `php script/tests/test_fill_wispertalk.php`
- `php script/tests/test_fill_call_ratings.php`


------
https://chatgpt.com/codex/tasks/task_e_689ca6cdac7c83318db614d42e3c24f3