### PR TITLE
Use response_format for OpenAI JSON schema output

### DIFF
--- a/public_html/openai_evaluate.php
+++ b/public_html/openai_evaluate.php
@@ -47,11 +47,13 @@ function openai_build_payload(string $transcript): array
                 'content' => $prompt,
             ],
         ],
-        'text' => [
-            'format' => [
-                'type' => 'json_schema',
+        // REM Enforce structured JSON output via response_format
+        'response_format' => [
+            'type' => 'json_schema',
+            'json_schema' => [
                 'name' => 'sales_call_evaluation',
                 'schema' => $schema,
+                'strict' => true,
             ],
         ],
         'max_output_tokens' => 500,

--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -3,7 +3,8 @@ require_once __DIR__ . '/../../public_html/openai_evaluate.php';
 
 $payload = openai_build_payload('sample transcript');
 
-if (($payload['text']['format']['name'] ?? '') !== 'sales_call_evaluation') {
+$jsonSchema = $payload['response_format']['json_schema'] ?? null;
+if (($jsonSchema['name'] ?? '') !== 'sales_call_evaluation') {
     fwrite(STDERR, "Missing or incorrect format name\n");
     exit(1);
 }
@@ -13,7 +14,7 @@ if (!is_array($payload['input']) || ($payload['input'][0]['role'] ?? '') !== 'us
     exit(1);
 }
 
-$schema = $payload['text']['format']['schema'] ?? null;
+$schema = $jsonSchema['schema'] ?? null;
 if (!is_array($schema) || !isset($schema['properties']['greeting_quality'])) {
     fwrite(STDERR, "Schema not structured as expected\n");
     exit(1);


### PR DESCRIPTION
## Summary
- Build OpenAI evaluation payload using `response_format` to request JSON-schema responses
- Adjust payload test to validate `response_format` structure and schema properties

## Testing
- `php -l public_html/openai_evaluate.php`
- `php -l script/tests/test_openai_payload.php`
- `python -m pytest script/tests/test_openai_payload.py`

------
https://chatgpt.com/codex/tasks/task_e_689caaf16b488331b96025a66d9645a0