### PR TITLE
Use text.format for OpenAI responses

### DIFF
--- a/public_html/openai_evaluate.php
+++ b/public_html/openai_evaluate.php
@@ -47,9 +47,9 @@ function openai_build_payload(string $transcript): array
                 'content' => $prompt,
             ],
         ],
-        // REM Enforce structured JSON output via response_format
-        'response_format' => [
-            'type' => 'json_schema',
+        // REM Enforce structured JSON output via text.format
+        'text' => [
+            'format' => 'json_schema',
             'json_schema' => [
                 'name' => 'sales_call_evaluation',
                 'schema' => $schema,

--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -3,8 +3,8 @@ require_once __DIR__ . '/../../public_html/openai_evaluate.php';
 
 $payload = openai_build_payload('sample transcript');
 
-$jsonSchema = $payload['response_format']['json_schema'] ?? null;
-if (($jsonSchema['name'] ?? '') !== 'sales_call_evaluation') {
+$jsonSchema = $payload['text']['json_schema'] ?? null;
+if (($payload['text']['format'] ?? '') !== 'json_schema' || ($jsonSchema['name'] ?? '') !== 'sales_call_evaluation') {
     fwrite(STDERR, "Missing or incorrect format name\n");
     exit(1);
 }


### PR DESCRIPTION
## Summary
- Replace deprecated `response_format` with `text.format` in `openai_evaluate`
- Adjust payload unit test for new `text.format` structure

## Testing
- `php script/tests/test_openai_payload.php`


------
https://chatgpt.com/codex/tasks/task_e_689cac323ed48331a305b5075b38c9c9