### PR TITLE
Use dedicated assistant for call rating evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
 - `script/rename_recording.php` – renames call recordings by mapping extension numbers to contact names; supports filenames like
  `out-123-0-8504-20250704-...` and `exten-8504-unknown-20250701-...`.
 - `script/fill_wispertalk.php` – populates the `WisperTALK` column in `sales_call_ratings` using MySQL (default DB `salescallsanalyse`) and OpenAI's Whisper API for entries missing transcripts; emits verbose debug to STDERR.
-- `script/fill_call_ratings.php` – evaluates `WisperTALK` transcripts with
-  OpenAI's GPT-5 model via the Responses API and updates scoring fields such as
-  `greeting_quality` and `WhatWorked`. The request uses `text.format` with a
-  JSON schema to force structured output and emits extensive debug information
-  to STDERR, including payload details and raw API responses.
+- `script/fill_call_ratings.php` – evaluates `WisperTALK` transcripts using the
+  OpenAI assistant `asst_dxSC2TjWn45PX7JDdM8RpiyQ` via the Responses API and
+  updates scoring fields such as `greeting_quality` and `WhatWorked`. The
+  request uses `text.format` with a JSON schema to force structured output and
+  emits extensive debug information to STDERR, including payload details and raw
+  API responses.
 - `config_files/config.php` – configuration for paths including the sound directory.
 - `documents/`, `business_information/`, `etc/` – placeholders for project
   organisation.
@@ -87,8 +88,11 @@ A cron entry can run the evaluation periodically and persist a timestamped log:
 */5 * * * * cd /path/to/wisperHVDK && OPENAI_API_KEY=your_key php script/cron_fill_call_ratings.php >> /var/log/wisper_ratings.log 2>&1
 ```
 
-The evaluation agent uses the OpenAI Responses API (`https://api.openai.com/v1/responses`) with the `gpt-5` model and the
-`sales_call_evaluation` schema defined in `public_html/openai_evaluate.php`.
+The evaluation agent uses the OpenAI Responses API
+(`https://api.openai.com/v1/responses`) with the assistant
+`asst_dxSC2TjWn45PX7JDdM8RpiyQ` and the `sales_call_evaluation` schema defined
+in `public_html/openai_evaluate.php`. Override the assistant via
+`OPENAI_ASSISTANT_ID` if required.
 
 ### Convert and save a transcript
 

--- a/script/fill_call_ratings.php
+++ b/script/fill_call_ratings.php
@@ -4,6 +4,9 @@
 
 require_once __DIR__ . '/../public_html/openai_evaluate.php';
 
+// REM Use predefined OpenAI assistant unless overridden via OPENAI_ASSISTANT_ID
+$assistantId = getenv('OPENAI_ASSISTANT_ID') ?: 'asst_dxSC2TjWn45PX7JDdM8RpiyQ';
+
 /**
  * Process rows missing rating information.
  *
@@ -99,7 +102,7 @@ if (realpath(__FILE__) === realpath($_SERVER['SCRIPT_FILENAME'])) {
         exit(1);
     }
 
-    $updated = process_missing_ratings($pdo, 'openai_evaluate');
+    $updated = process_missing_ratings($pdo, fn(string $talk): array => openai_evaluate($talk, $assistantId));
     fwrite(STDOUT, "Updated {$updated} record(s)\n");
 }
 ?>

--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -1,7 +1,12 @@
 <?php
 require_once __DIR__ . '/../../public_html/openai_evaluate.php';
 
-$payload = openai_build_payload('sample transcript');
+$payload = openai_build_payload('sample transcript', 'asst_test');
+
+if (($payload['assistant_id'] ?? '') !== 'asst_test') {
+    fwrite(STDERR, "Assistant ID not set correctly\n");
+    exit(1);
+}
 
 $jsonSchema = $payload['response_format']['json_schema'] ?? null;
 if (($payload['response_format']['type'] ?? '') !== 'json_schema' || ($jsonSchema['name'] ?? '') !== 'sales_call_evaluation') {


### PR DESCRIPTION
## Summary
- Route call rating evaluations through a fixed OpenAI assistant, defaulting to `asst_dxSC2TjWn45PX7JDdM8RpiyQ`
- Propagate assistant usage in the evaluation script and tests
- Document assistant configuration in README

## Testing
- `pytest`
- `php script/tests/test_fill_wispertalk.php`
- `php script/tests/test_fill_call_ratings.php`


------
https://chatgpt.com/codex/tasks/task_e_689d8570473c83318bf58df338f7a40d