### PR TITLE
Update OpenAI request for text.format

### DIFF
--- a/public_html/openai_evaluate.php
+++ b/public_html/openai_evaluate.php
@@ -48,13 +48,15 @@ function openai_build_payload(string $transcript, string $assistantId): array
                 'content' => $prompt,
             ],
         ],
-        // REM Enforce structured JSON output via response_format
-        'response_format' => [
-            'type' => 'json_schema',
-            'json_schema' => [
-                'name' => 'sales_call_evaluation',
-                'schema' => $schema,
-                'strict' => true,
+        // REM Enforce structured JSON output via text.format
+        'text' => [
+            'format' => [
+                'type' => 'json_schema',
+                'json_schema' => [
+                    'name' => 'sales_call_evaluation',
+                    'schema' => $schema,
+                    'strict' => true,
+                ],
             ],
         ],
         'max_output_tokens' => 500,

--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -8,8 +8,8 @@ if (($payload['assistant_id'] ?? '') !== 'asst_test') {
     exit(1);
 }
 
-$jsonSchema = $payload['response_format']['json_schema'] ?? null;
-if (($payload['response_format']['type'] ?? '') !== 'json_schema' || ($jsonSchema['name'] ?? '') !== 'sales_call_evaluation') {
+$jsonSchema = $payload['text']['format']['json_schema'] ?? null;
+if (($payload['text']['format']['type'] ?? '') !== 'json_schema' || ($jsonSchema['name'] ?? '') !== 'sales_call_evaluation') {
     fwrite(STDERR, "Missing or incorrect format name\n");
     exit(1);
 }


### PR DESCRIPTION
## Summary
- use new `text.format` structure in OpenAI Responses payload
- adjust tests for new payload shape

## Testing
- `php -l public_html/openai_evaluate.php`
- `php script/tests/test_openai_payload.php`


------
https://chatgpt.com/codex/tasks/task_e_689d89800a14833193f10c7cfcd498f1