### PR TITLE
Add required model parameter to OpenAI evaluation payload

### DIFF
--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -1,10 +1,16 @@
 <?php
 require_once __DIR__ . '/../../public_html/openai_evaluate.php';
 
+putenv('OPENAI_MODEL=test-model');
 $payload = openai_build_payload('sample transcript', 'asst_test');
 
 if (($payload['assistant_id'] ?? '') !== 'asst_test') {
     fwrite(STDERR, "Assistant ID not set correctly\n");
+    exit(1);
+}
+
+if (($payload['model'] ?? '') !== 'test-model') {
+    fwrite(STDERR, "Model not set correctly\n");
     exit(1);
 }
 


### PR DESCRIPTION
## Summary
- include `model` field in evaluation payload and allow configuration via `OPENAI_MODEL`
- document model usage and update tests for new parameter

## Testing
- `php script/tests/test_openai_payload.php && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_689d8a833198833181f56d7ebddc7e91