### PR TITLE
Remove assistant_id from OpenAI payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,10 @@ Prototype demonstrating how a Laravel-compatible PHP script can invoke the
  `out-123-0-8504-20250704-...` and `exten-8504-unknown-20250701-...`.
 - `script/fill_wispertalk.php` – populates the `WisperTALK` column in `sales_call_ratings` using MySQL (default DB `salescallsanalyse`) and OpenAI's Whisper API for entries missing transcripts; emits verbose debug to STDERR.
 - `script/fill_call_ratings.php` – evaluates `WisperTALK` transcripts using the
-  OpenAI assistant `asst_dxSC2TjWn45PX7JDdM8RpiyQ` via the Responses API and
-  updates scoring fields such as `greeting_quality` and `WhatWorked`. The
-  request uses `text.format` with a JSON schema to force structured output and
-  emits extensive debug information to STDERR, including payload details and raw
-  API responses.
+  OpenAI Responses API (default model `gpt-4o`) and updates scoring fields such
+  as `greeting_quality` and `WhatWorked`. The request uses `text.format` with a
+  JSON schema to force structured output and emits extensive debug information to
+  STDERR, including payload details and raw API responses.
 - `config_files/config.php` – configuration for paths including the sound directory.
 - `documents/`, `business_information/`, `etc/` – placeholders for project
   organisation.
@@ -89,10 +88,9 @@ A cron entry can run the evaluation periodically and persist a timestamped log:
 ```
 
 The evaluation agent uses the OpenAI Responses API
-(`https://api.openai.com/v1/responses`) with the assistant
-`asst_dxSC2TjWn45PX7JDdM8RpiyQ` and the `sales_call_evaluation` schema defined
-in `public_html/openai_evaluate.php`. Override the assistant via
-`OPENAI_ASSISTANT_ID` if required.
+(`https://api.openai.com/v1/responses`) with the `sales_call_evaluation` schema
+defined in `public_html/openai_evaluate.php`. Override the model via
+`OPENAI_MODEL` if required.
 
 ### Convert and save a transcript
 

--- a/script/fill_call_ratings.php
+++ b/script/fill_call_ratings.php
@@ -4,9 +4,6 @@
 
 require_once __DIR__ . '/../public_html/openai_evaluate.php';
 
-// REM Use predefined OpenAI assistant unless overridden via OPENAI_ASSISTANT_ID
-$assistantId = getenv('OPENAI_ASSISTANT_ID') ?: 'asst_dxSC2TjWn45PX7JDdM8RpiyQ';
-
 /**
  * Process rows missing rating information.
  *
@@ -102,7 +99,7 @@ if (realpath(__FILE__) === realpath($_SERVER['SCRIPT_FILENAME'])) {
         exit(1);
     }
 
-    $updated = process_missing_ratings($pdo, fn(string $talk): array => openai_evaluate($talk, $assistantId));
+    $updated = process_missing_ratings($pdo, fn(string $talk): array => openai_evaluate($talk));
     fwrite(STDOUT, "Updated {$updated} record(s)\n");
 }
 ?>

--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -2,10 +2,10 @@
 require_once __DIR__ . '/../../public_html/openai_evaluate.php';
 
 putenv('OPENAI_MODEL=test-model');
-$payload = openai_build_payload('sample transcript', 'asst_test');
+$payload = openai_build_payload('sample transcript');
 
-if (($payload['assistant_id'] ?? '') !== 'asst_test') {
-    fwrite(STDERR, "Assistant ID not set correctly\n");
+if (isset($payload['assistant_id'])) {
+    fwrite(STDERR, "assistant_id should not be present\n");
     exit(1);
 }
 


### PR DESCRIPTION
## Summary
- Remove deprecated `assistant_id` from OpenAI Responses API payload builder and evaluation helper.
- Update call rating script and tests to reflect payload change.
- Refresh README to describe model-based configuration instead of assistant usage.

## Testing
- `php script/tests/test_openai_payload.php`
- `php script/tests/test_fill_call_ratings.php`
- `python script/tests/test_openai_payload.py`
- `python script/tests/test_fill_call_ratings.py`


------
https://chatgpt.com/codex/tasks/task_e_689d8d49d8588331ab28428d08b47f0e