### PR TITLE
Fix OpenAI assistant calls by adding beta header

### DIFF
--- a/public_html/openai_evaluate.php
+++ b/public_html/openai_evaluate.php
@@ -115,6 +115,21 @@ function openai_extract_output_text(array $json): ?string
 }
 
 /**
+ * Build HTTP headers for OpenAI API requests.
+ *
+ * @param string $apiKey Secret token for Authorization header
+ * @return array<int,string> Array of HTTP header lines
+ */
+function openai_build_headers(string $apiKey): array
+{
+    return [
+        'Content-Type: application/json',
+        'Authorization: Bearer ' . $apiKey,
+        'OpenAI-Beta: assistants=v2',
+    ];
+}
+
+/**
  * Send transcript text to OpenAI and return structured evaluation data.
  *
  * @param string      $transcript  Full transcript to analyse
@@ -141,10 +156,7 @@ function openai_evaluate(string $transcript, ?string $assistantId = null): array
     $ch = curl_init('https://api.openai.com/v1/responses');
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_HTTPHEADER => [
-            'Content-Type: application/json',
-            'Authorization: Bearer ' . $apiKey,
-        ],
+        CURLOPT_HTTPHEADER => openai_build_headers($apiKey),
         CURLOPT_POST => true,
         CURLOPT_POSTFIELDS => json_encode($payload),
     ]);

--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -4,6 +4,12 @@ require_once __DIR__ . '/../../public_html/openai_evaluate.php';
 putenv('OPENAI_MODEL=test-model');
 $payload = openai_build_payload('sample transcript', 'asst_test');
 
+$headers = openai_build_headers('key123');
+if (!in_array('OpenAI-Beta: assistants=v2', $headers, true)) {
+    fwrite(STDERR, "Missing OpenAI-Beta header\n");
+    exit(1);
+}
+
 if (($payload['assistant_id'] ?? '') !== 'asst_test') {
     fwrite(STDERR, "Assistant ID not set correctly\n");
     exit(1);


### PR DESCRIPTION
## Summary
- add helper to build OpenAI HTTP headers with `OpenAI-Beta: assistants=v2`
- cover header helper in test suite

## Testing
- `pytest`
- `php script/tests/test_fill_wispertalk.php`
- `php script/tests/test_fill_call_ratings.php`
- `php script/tests/test_openai_payload.php`


------
https://chatgpt.com/codex/tasks/task_e_689d8f15418c8331a3b76485dc030d8d