### PR TITLE
Use assistant helper in evaluation

### DIFF
--- a/script/tests/stub_openai_assistant.php
+++ b/script/tests/stub_openai_assistant.php
@@ -1,0 +1,41 @@
+<?php
+// REM Stub implementation for oa_* functions used in tests
+$__stub_calls = [];
+
+function oa_init_ctx(string $api_key, ?string $assistant_id = null, string $base_url = '', string $version_header = ''): array {
+    global $__stub_calls;
+    $__stub_calls[] = ['oa_init_ctx', func_get_args()];
+    return ['api_key' => $api_key, 'assistant_id' => $assistant_id];
+}
+
+function oa_create_assistant(array &$ctx, string $name, string $instructions, array $tools, string $model = ''): string {
+    global $__stub_calls;
+    $__stub_calls[] = ['oa_create_assistant', func_get_args()];
+    $ctx['assistant_id'] = 'stub-assistant';
+    return 'stub-assistant';
+}
+
+function oa_create_thread(array $ctx, string $content, string $role = 'user'): string {
+    global $__stub_calls;
+    $__stub_calls[] = ['oa_create_thread', func_get_args()];
+    return 'stub-thread';
+}
+
+function oa_run_thread(array &$ctx, string $thread_id) {
+    global $__stub_calls;
+    $__stub_calls[] = ['oa_run_thread', func_get_args()];
+    return 'stub-run';
+}
+
+function oa_list_thread_messages(array $ctx, string $thread_id): array {
+    global $__stub_calls;
+    $__stub_calls[] = ['oa_list_thread_messages', func_get_args()];
+    return [
+        [
+            'role' => 'assistant',
+            'content' => [
+                ['text' => ['value' => '{"greeting_quality":5,"needs_assessment":4,"product_knowledge":3,"persuasion":4,"closing":5,"WhatWorked":"good","WhatDidNotWork":"none","manager_comment":"nice"}']]
+            ],
+        ],
+    ];
+}

--- a/script/tests/test_openai_evaluate.php
+++ b/script/tests/test_openai_evaluate.php
@@ -1,0 +1,18 @@
+<?php
+define('OA_LIB_PATH', __DIR__ . '/stub_openai_assistant.php');
+require_once __DIR__ . '/../../public_html/openai_evaluate.php';
+
+putenv('OPENAI_API_KEY=dummy');
+
+$result = openai_evaluate('sample transcript');
+if (($result['greeting_quality'] ?? null) !== 5) {
+    fwrite(STDERR, "Unexpected evaluation result\n");
+    exit(1);
+}
+
+global $__stub_calls;
+$create = array_filter($__stub_calls, fn($c) => $c[0] === 'oa_create_assistant');
+if (count($create) !== 1) {
+    fwrite(STDERR, "Assistant creation not invoked\n");
+    exit(1);
+}


### PR DESCRIPTION
## Summary
- Load OpenAI assistant helper in evaluation script
- Create and run assistant threads to rate transcripts
- Add stub and test verifying assistant creation

## Testing
- `php script/tests/test_openai_payload.php`
- `php script/tests/test_openai_evaluate.php`


------
https://chatgpt.com/codex/tasks/task_e_689da0528a9c83318f934d2d076fc23f