### PR TITLE
Add verbose debugging to OpenAI evaluation

### DIFF
--- a/script/tests/stub_openai_assistant.php
+++ b/script/tests/stub_openai_assistant.php
@@ -2,6 +2,9 @@
 // REM Stub implementation for oa_* functions used in tests
 $__stub_calls = [];
 
+// No-op debug function for tests
+function oa_debug(string $message): void {}
+
 function oa_init_ctx(string $api_key, ?string $assistant_id = null, string $base_url = '', string $version_header = ''): array {
     global $__stub_calls;
     $__stub_calls[] = ['oa_init_ctx', func_get_args()];


### PR DESCRIPTION
## Summary
- add OA_DEBUG flag and request/response tracing to OpenAI assistant helper
- log evaluation steps and handle exceptions in openai_evaluate
- include oa_debug stub in tests

## Testing
- `php script/tests/test_openai_payload.php`
- `php script/tests/test_openai_evaluate.php`
- `php script/tests/test_fill_call_ratings.php`
- `php script/tests/test_fill_wispertalk.php`
- `python script/tests/test_openai_payload.py`
- `python script/tests/test_fill_call_ratings.py`
- `python script/tests/test_fill_wispertalk.py`
- `python script/tests/test_insert_sound_files.py`


------
https://chatgpt.com/codex/tasks/task_e_689daffa37748331b4daeb97915ea594