### PR TITLE
Add warning_comment field to sales call ratings

### DIFF
--- a/database/salescallsanalyse.sql
+++ b/database/salescallsanalyse.sql
@@ -40,6 +40,7 @@ CREATE TABLE `sales_call_ratings` (
   `WhatWorked` varchar(1024) NOT NULL,
   `WhatDidNotWork` varchar(1024) NOT NULL,
   `manager_comment` text DEFAULT NULL,
+  `warning_comment` text DEFAULT NULL,
   `created_at` timestamp NOT NULL DEFAULT current_timestamp()
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 

--- a/public_html/openai_evaluate.php
+++ b/public_html/openai_evaluate.php
@@ -31,6 +31,7 @@ function openai_build_payload(string $transcript, string $assistantId, ?string $
             'WhatWorked' => ['type' => 'string'],
             'WhatDidNotWork' => ['type' => 'string'],
             'manager_comment' => ['type' => 'string'],
+            'warning_comment' => ['type' => 'string'],
         ],
         'required' => [
             'greeting_quality',
@@ -41,12 +42,13 @@ function openai_build_payload(string $transcript, string $assistantId, ?string $
             'WhatWorked',
             'WhatDidNotWork',
             'manager_comment',
+            'warning_comment',
         ],
     ];
 
     $prompt = 'Assess the following sales call transcript. Rate each category on a '
         . 'scale of 1-5 and provide brief notes for WhatWorked, WhatDidNotWork, '
-        . 'and a manager_comment. Transcript: ' . $transcript;
+        . 'and both a manager_comment and a warning_comment. Transcript: ' . $transcript;
 
     return [
         'assistant_id' => $assistantId,
@@ -161,9 +163,9 @@ function openai_evaluate(string $transcript, ?string $assistantId = null): array
         oa_debug('Initialised context');
         $instructions = 'Assess the following sales call transcript. Rate each category on a '
             . 'scale of 1-5 and provide brief notes for WhatWorked, WhatDidNotWork, '
-            . 'and a manager_comment. Reply strictly in JSON with keys '
+            . 'and both a manager_comment and a warning_comment. Reply strictly in JSON with keys '
             . 'greeting_quality, needs_assessment, product_knowledge, persuasion, '
-            . 'closing, WhatWorked, WhatDidNotWork and manager_comment.';
+            . 'closing, WhatWorked, WhatDidNotWork, manager_comment and warning_comment.';
 
         if (empty($assistantId)) {
             $assistantId = oa_create_assistant($ctx, 'Sales Call Evaluator', $instructions, [], $model);

--- a/script/fill_call_ratings.php
+++ b/script/fill_call_ratings.php
@@ -19,7 +19,7 @@ function process_missing_ratings(PDO $pdo, callable $evaluate): int
     $select = "SELECT id, WisperTALK FROM sales_call_ratings "
         . "WHERE greeting_quality = 0 OR needs_assessment = 0 OR "
         . "product_knowledge = 0 OR persuasion = 0 OR closing = 0 OR "
-        . "WhatWorked = '' OR WhatDidNotWork = '' OR manager_comment IS NULL";
+        . "WhatWorked = '' OR WhatDidNotWork = '' OR manager_comment IS NULL OR warning_comment IS NULL";
     fwrite(STDERR, "Running query: {$select}\n");
     $rows = $pdo->query($select)->fetchAll(PDO::FETCH_ASSOC);
     fwrite(STDERR, "Found " . count($rows) . " row(s) needing evaluation\n");
@@ -33,7 +33,8 @@ function process_missing_ratings(PDO $pdo, callable $evaluate): int
         . "closing = :closing, "
         . "WhatWorked = :WhatWorked, "
         . "WhatDidNotWork = :WhatDidNotWork, "
-        . "manager_comment = :manager_comment "
+        . "manager_comment = :manager_comment, "
+        . "warning_comment = :warning_comment "
         . "WHERE id = :id"
     );
 
@@ -57,6 +58,7 @@ function process_missing_ratings(PDO $pdo, callable $evaluate): int
             ':WhatWorked' => (string) ($result['WhatWorked'] ?? ''),
             ':WhatDidNotWork' => (string) ($result['WhatDidNotWork'] ?? ''),
             ':manager_comment' => $result['manager_comment'] ?? null,
+            ':warning_comment' => $result['warning_comment'] ?? null,
             ':id' => (int) $row['id'],
         ]);
         $count++;

--- a/script/tests/stub_openai_assistant.php
+++ b/script/tests/stub_openai_assistant.php
@@ -37,7 +37,7 @@ function oa_list_thread_messages(array $ctx, string $thread_id): array {
         [
             'role' => 'assistant',
             'content' => [
-                ['text' => ['value' => '{"greeting_quality":5,"needs_assessment":4,"product_knowledge":3,"persuasion":4,"closing":5,"WhatWorked":"good","WhatDidNotWork":"none","manager_comment":"nice"}']]
+                ['text' => ['value' => '{"greeting_quality":5,"needs_assessment":4,"product_knowledge":3,"persuasion":4,"closing":5,"WhatWorked":"good","WhatDidNotWork":"none","manager_comment":"nice","warning_comment":"caution"}']]
             ],
         ],
     ];

--- a/script/tests/test_fill_call_ratings.php
+++ b/script/tests/test_fill_call_ratings.php
@@ -16,7 +16,8 @@ $pdo->exec("CREATE TABLE IF NOT EXISTS sales_call_ratings (
     closing INTEGER NOT NULL DEFAULT 0,
     WhatWorked TEXT NOT NULL DEFAULT '',
     WhatDidNotWork TEXT NOT NULL DEFAULT '',
-    manager_comment TEXT
+    manager_comment TEXT,
+    warning_comment TEXT
 )");
 $pdo->exec("INSERT INTO sales_call_ratings (WisperTALK) VALUES ('example talk')");
 
@@ -30,11 +31,12 @@ process_missing_ratings($pdo, function (string $talk): array {
         'WhatWorked' => 'good knowledge',
         'WhatDidNotWork' => 'weak closing',
         'manager_comment' => 'improve closing',
+        'warning_comment' => 'check closing',
     ];
 });
 
-$row = $pdo->query('SELECT greeting_quality, needs_assessment, product_knowledge, persuasion, closing, WhatWorked, WhatDidNotWork, manager_comment FROM sales_call_ratings')->fetch(PDO::FETCH_ASSOC);
-if ($row['greeting_quality'] != 3 || $row['needs_assessment'] != 4 || $row['product_knowledge'] != 5 || $row['persuasion'] != 2 || $row['closing'] != 1 || $row['WhatWorked'] !== 'good knowledge' || $row['WhatDidNotWork'] !== 'weak closing' || $row['manager_comment'] !== 'improve closing') {
+$row = $pdo->query('SELECT greeting_quality, needs_assessment, product_knowledge, persuasion, closing, WhatWorked, WhatDidNotWork, manager_comment, warning_comment FROM sales_call_ratings')->fetch(PDO::FETCH_ASSOC);
+if ($row['greeting_quality'] != 3 || $row['needs_assessment'] != 4 || $row['product_knowledge'] != 5 || $row['persuasion'] != 2 || $row['closing'] != 1 || $row['WhatWorked'] !== 'good knowledge' || $row['WhatDidNotWork'] !== 'weak closing' || $row['manager_comment'] !== 'improve closing' || $row['warning_comment'] !== 'check closing') {
     fwrite(STDERR, "Test failed\n");
     exit(1);
 }

--- a/script/tests/test_fill_call_ratings.py
+++ b/script/tests/test_fill_call_ratings.py
@@ -18,7 +18,8 @@ def test_fill_call_ratings(tmp_path: Path) -> None:
             closing INTEGER NOT NULL DEFAULT 0,
             WhatWorked TEXT NOT NULL DEFAULT '',
             WhatDidNotWork TEXT NOT NULL DEFAULT '',
-            manager_comment TEXT
+            manager_comment TEXT,
+            warning_comment TEXT
         )
         """
     )
@@ -40,8 +41,8 @@ def test_fill_call_ratings(tmp_path: Path) -> None:
 
     conn = sqlite3.connect(db_file)
     row = conn.execute(
-        "SELECT greeting_quality, needs_assessment, product_knowledge, persuasion, closing, WhatWorked, WhatDidNotWork, manager_comment FROM sales_call_ratings"
+        "SELECT greeting_quality, needs_assessment, product_knowledge, persuasion, closing, WhatWorked, WhatDidNotWork, manager_comment, warning_comment FROM sales_call_ratings"
     ).fetchone()
     conn.close()
 
-    assert row == (3, 4, 5, 2, 1, "good knowledge", "weak closing", "improve closing")
+    assert row == (3, 4, 5, 2, 1, "good knowledge", "weak closing", "improve closing", "check closing")

--- a/script/tests/test_insert_sound_files.py
+++ b/script/tests/test_insert_sound_files.py
@@ -41,6 +41,7 @@ def test_insert_sound_files(tmp_path: Path) -> None:
             persuasion INTEGER NOT NULL,
             closing INTEGER NOT NULL,
             manager_comment TEXT,
+            warning_comment TEXT,
             created_at TEXT DEFAULT CURRENT_TIMESTAMP
         )
         """

--- a/script/tests/test_openai_evaluate.php
+++ b/script/tests/test_openai_evaluate.php
@@ -10,6 +10,11 @@ if (($result['greeting_quality'] ?? null) !== 5) {
     exit(1);
 }
 
+if (($result['warning_comment'] ?? null) !== 'caution') {
+    fwrite(STDERR, "warning_comment not returned\n");
+    exit(1);
+}
+
 global $__stub_calls;
 $create = array_filter($__stub_calls, fn($c) => $c[0] === 'oa_create_assistant');
 if (count($create) !== 1) {

--- a/script/tests/test_openai_payload.php
+++ b/script/tests/test_openai_payload.php
@@ -37,6 +37,11 @@ if (!is_array($schema) || !isset($schema['properties']['greeting_quality'])) {
     exit(1);
 }
 
+if (!isset($schema['properties']['warning_comment']) || !in_array('warning_comment', $schema['required'] ?? [], true)) {
+    fwrite(STDERR, "warning_comment missing from schema\n");
+    exit(1);
+}
+
 if (($schema['additionalProperties'] ?? null) !== false) {
     fwrite(STDERR, "additionalProperties must be false\n");
     exit(1);


### PR DESCRIPTION
## Summary
- support `warning_comment` in OpenAI evaluation payload and instructions
- persist `warning_comment` to `sales_call_ratings` table
- exercise new field in tests and stub helper

## Testing
- `pytest`
- `php script/tests/test_fill_wispertalk.php`
- `php script/tests/test_fill_call_ratings.php`
- `php script/tests/test_openai_payload.php`
- `php script/tests/test_openai_evaluate.php`


------
https://chatgpt.com/codex/tasks/task_e_689db9afb0108331aa031978392cd1e7