### PR TITLE
Add command to import short WAV files into database

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,12 @@ To delete `.wav` files shorter than one minute within a directory (default is `s
 php script/delete_short_files.php /path/to/dir
 ```
 
+To insert short WAV files into the database:
+
+```bash
+php artisan insert:sound-files /path/to/dir
+```
+
 ## Testing
 
 ```bash

--- a/app/Console/Commands/InsertSoundFiles.php
+++ b/app/Console/Commands/InsertSoundFiles.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use RecursiveIteratorIterator;
+use RecursiveDirectoryIterator;
+use FilesystemIterator;
+
+class InsertSoundFiles extends Command
+{
+    protected $signature = 'insert:sound-files {directory? : Directory to scan for WAV files}';
+    protected $description = 'Insert qualifying WAV files into sales_call_ratings';
+
+    public function handle(): int
+    {
+        $directory = $this->argument('directory') ?? 'C:\\wisper\\sound';
+
+        if (!is_dir($directory)) {
+            $this->error("Directory not found: {$directory}");
+            return 1;
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || strtolower($file->getExtension()) !== 'wav') {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            $duration = $this->getWavDuration($path);
+
+            if ($duration !== null && $duration < 120) {
+                $callId = pathinfo($path, PATHINFO_FILENAME);
+                try {
+                    DB::table('sales_call_ratings')->insert([
+                        'filepath' => $path,
+                        'call_id' => $callId,
+                        'greeting_quality' => 0,
+                        'needs_assessment' => 0,
+                        'product_knowledge' => 0,
+                        'persuasion' => 0,
+                        'closing' => 0,
+                    ]);
+                } catch (\Throwable $e) {
+                    $this->warn("Failed to insert {$path}: " . $e->getMessage());
+                }
+            }
+        }
+
+        $this->info('Insert sound files completed');
+        return 0;
+    }
+
+    private function getWavDuration(string $file): ?float
+    {
+        $handle = @fopen($file, 'rb');
+        if ($handle === false) {
+            return null;
+        }
+
+        fseek($handle, 22);
+        $channels = unpack('v', fread($handle, 2))[1] ?? 0;
+        $sampleRate = unpack('V', fread($handle, 4))[1] ?? 0;
+        fseek($handle, 34);
+        $bitsPerSample = unpack('v', fread($handle, 2))[1] ?? 0;
+        fseek($handle, 40);
+        $dataSize = unpack('V', fread($handle, 4))[1] ?? 0;
+        fclose($handle);
+
+        if ($channels === 0 || $bitsPerSample === 0 || $sampleRate === 0) {
+            return null;
+        }
+
+        $bytesPerSample = ($bitsPerSample / 8) * $channels;
+        return $dataSize / ($sampleRate * $bytesPerSample);
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true" verbose="true">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory>./tests/Feature</directory>
+        </testsuite>
+        <testsuite name="Unit">
+            <directory>./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
+    </php>
+</phpunit>

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Application;
+
+trait CreatesApplication
+{
+    public function createApplication(): Application
+    {
+        $app = require __DIR__.'/../bootstrap/app.php';
+        $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+        return $app;
+    }
+}

--- a/tests/Feature/InsertSoundFilesCommandTest.php
+++ b/tests/Feature/InsertSoundFilesCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class InsertSoundFilesCommandTest extends TestCase
+{
+    public function testInsertsShortWavFiles(): void
+    {
+        $dir = sys_get_temp_dir().'/wavtest'.uniqid();
+        mkdir($dir);
+        $path = $dir.'/test.wav';
+        file_put_contents($path, $this->generateWav(1));
+
+        DB::statement('CREATE TABLE sales_call_ratings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            filepath TEXT,
+            call_id TEXT,
+            greeting_quality INTEGER,
+            needs_assessment INTEGER,
+            product_knowledge INTEGER,
+            persuasion INTEGER,
+            closing INTEGER
+        )');
+
+        Artisan::call('insert:sound-files', ['directory' => $dir]);
+
+        $this->assertDatabaseHas('sales_call_ratings', [
+            'filepath' => $path,
+            'call_id' => 'test',
+        ]);
+    }
+
+    private function generateWav(int $seconds): string
+    {
+        $sampleRate = 8000;
+        $numSamples = $seconds * $sampleRate;
+        $data = str_repeat(pack('v', 0), $numSamples);
+        $header = 'RIFF'.
+            pack('V', 36 + strlen($data)).
+            'WAVEfmt '.
+            pack('V', 16).
+            pack('v', 1).
+            pack('v', 1).
+            pack('V', $sampleRate).
+            pack('V', $sampleRate * 2).
+            pack('v', 2).
+            pack('v', 16).
+            'data'.
+            pack('V', strlen($data));
+        return $header.$data;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+}


### PR DESCRIPTION
## Summary
- add `insert:sound-files` artisan command to scan directories for short WAV recordings and store them in `sales_call_ratings`
- document usage of new command
- provide PHPUnit configuration and feature test for the command

## Testing
- `php -l app/Console/Commands/InsertSoundFiles.php`
- `php -l tests/CreatesApplication.php`
- `php -l tests/TestCase.php`
- `php -l tests/Feature/InsertSoundFilesCommandTest.php`
- `php artisan test` *(fails: Failed opening required '/workspace/wisperHVDK/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68aede2791e88331baa464d8d7c2fbae