### PR TITLE
Convert large audio files to MP3 before transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ DB_HOST=127.0.01
 - `public_html/index.php` – Laravel front controller
 - `public_html/transcribe.php` – PHP entry point that calls the Python helper.
 - `public_html/openai_transcribe.php` – PHP script calling OpenAI's Whisper API and
-  returning a timestamped transcript with CRLF line endings.
+  returning a timestamped transcript with CRLF line endings. WAV files over
+  ~13 MB are converted to MP3 automatically to avoid API upload limits.
 
 - `script/convert_all.bat` – Windows helper to batch transcribe `.wav` files; skips files with an existing non-empty `.txt` transcript and produces an empty `.txt` for silent audio.
 - `script/whisper_transcribe.py` – Python script performing the transcription. It
@@ -89,6 +90,9 @@ To transcribe a file using the OpenAI API:
 ```bash
 OPENAI_API_KEY=your_key php public_html/openai_transcribe.php path/to/audio.wav
 ```
+
+If the input exceeds half of the API's 25 MB limit, the script compresses the
+audio to MP3 before uploading.
 
 To populate missing `WisperTALK` values in the database:
 

--- a/public_html/openai_transcribe.php
+++ b/public_html/openai_transcribe.php
@@ -29,6 +29,43 @@ function format_transcript_segments(array $segments): string
 }
 
 /**
+ * Prepare an audio file for upload. If the file exceeds half of the
+ * OpenAI content limit (default 25 MB) it is converted to MP3 to reduce
+ * size. Returns an array with the path to use, mime type and an optional
+ * temporary path that should be cleaned up by the caller.
+ *
+ * @return array{0:string,1:string,2:?string}
+ */
+function prepare_audio_for_openai(string $audioPath): array
+{
+    $maxSize = (int) getenv('OPENAI_MAX_CONTENT');
+    if ($maxSize <= 0) {
+        $maxSize = 26214400; // 25 MB default limit
+    }
+
+    $size = filesize($audioPath);
+    if ($size !== false && $size > ($maxSize / 2)) {
+        $ffmpeg = getenv('FFMPEG_BIN') ?: 'ffmpeg';
+        $tmp    = tempnam(sys_get_temp_dir(), 'wisper');
+        if ($tmp !== false) {
+            $tmp .= '.mp3';
+            $cmd = sprintf(
+                '%s -y -i %s -vn -ar 16000 -ac 1 -b:a 64k %s 2>&1',
+                escapeshellcmd($ffmpeg),
+                escapeshellarg($audioPath),
+                escapeshellarg($tmp)
+            );
+            exec($cmd, $out, $code);
+            if ($code === 0 && file_exists($tmp)) {
+                return [$tmp, 'audio/mpeg', $tmp];
+            }
+        }
+    }
+
+    return [$audioPath, 'audio/wav', null];
+}
+
+/**
  * Transcribe the given audio file using OpenAI's Whisper API.
  */
 function openai_transcribe(string $audioPath): string
@@ -44,8 +81,9 @@ function openai_transcribe(string $audioPath): string
     if ($apiKey === false || $apiKey === '') {
         return 'Error: missing API key';
     }
+    [$sendPath, $mime, $tmp] = prepare_audio_for_openai($audioPath);
     $ch = curl_init('https://api.openai.com/v1/audio/transcriptions');
-    $cfile = curl_file_create($audioPath, 'audio/wav', basename($audioPath));
+    $cfile = curl_file_create($sendPath, $mime, basename($sendPath));
     $data = [
         'model' => 'whisper-1',
         'file' => $cfile,
@@ -67,6 +105,9 @@ function openai_transcribe(string $audioPath): string
     }
     $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
     curl_close($ch);
+    if ($tmp !== null) {
+        @unlink($tmp);
+    }
     $json = json_decode($response, true);
     if ($status !== 200 || !is_array($json)) {
         return 'Error: API request failed';

--- a/tests/Feature/PrepareAudioForOpenAiTest.php
+++ b/tests/Feature/PrepareAudioForOpenAiTest.php
@@ -1,0 +1,49 @@
+<?php
+namespace Tests\Feature;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../public_html/openai_transcribe.php';
+
+class PrepareAudioForOpenAiTest extends TestCase
+{
+    public function testUsesOriginalWhenSmall(): void
+    {
+        $wav = tempnam(sys_get_temp_dir(), 'wisper') . '.wav';
+        file_put_contents($wav, str_repeat('a', 10));
+        putenv('OPENAI_MAX_CONTENT=1000');
+        [$path, $mime] = prepare_audio_for_openai($wav);
+        $this->assertSame($wav, $path);
+        $this->assertSame('audio/wav', $mime);
+        unlink($wav);
+    }
+
+    public function testConvertsLargeWavToMp3(): void
+    {
+        $wav = tempnam(sys_get_temp_dir(), 'wisper') . '.wav';
+        file_put_contents($wav, str_repeat('a', 600));
+
+        $ffmpeg = tempnam(sys_get_temp_dir(), 'ffmpeg');
+        file_put_contents($ffmpeg, "#!/bin/sh\n" .
+            "in=''\n" .
+            "while [ $# -gt 0 ]; do\n" .
+            "  if [ \"$1\" = '-i' ]; then in=$2; shift 2; continue; fi\n" .
+            "  out=$1; shift;\n" .
+            "done\n" .
+            "cp \"$in\" \"$out\"\n");
+        chmod($ffmpeg, 0755);
+        putenv('FFMPEG_BIN=' . $ffmpeg);
+        putenv('OPENAI_MAX_CONTENT=1000');
+
+        [$path, $mime, $tmp] = prepare_audio_for_openai($wav);
+        $this->assertNotSame($wav, $path);
+        $this->assertSame('audio/mpeg', $mime);
+        $this->assertFileExists($path);
+
+        if ($tmp !== null && file_exists($tmp)) {
+            unlink($tmp);
+        }
+        unlink($wav);
+        unlink($ffmpeg);
+    }
+}


### PR DESCRIPTION
## Summary
- Compress WAV inputs over ~13 MB to MP3 before calling Whisper API
- Document automatic MP3 conversion and cover helper with tests

## Testing
- `vendor/bin/phpunit --no-coverage` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b024faf74c8331bbfe00e35b408ee3