### PR TITLE
Chunk oversized audio before OpenAI transcription

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ OPENAI_API_KEY=your_key php public_html/openai_transcribe.php path/to/audio.wav
 ```
 
 If the input exceeds half of the API's 25 MB limit, the script compresses the
-audio to MP3 before uploading.
+audio to MP3 and automatically splits oversized files into smaller chunks
+before uploading.
 
 To populate missing `WisperTALK` values in the database:
 

--- a/app/Console/Commands/FillWisperTalk.php
+++ b/app/Console/Commands/FillWisperTalk.php
@@ -142,23 +142,29 @@ class FillWisperTalk extends Command
             return 'Error: audio file not found';
         }
 
-        // Primary attempt
-        $resp = $this->callOpenAI($apiKey, $audioPath, $model, $responseFormat);
-        if ($resp['ok']) {
-            return (string) $resp['body'];
-        }
+        // Ensure chunk helper functions are loaded
+        require_once base_path('public_html/openai_transcribe.php');
 
-        // If model rejects the format, fall back to 'text'
-        $bodyLower = strtolower($resp['body']);
-        if ($resp['status'] === 400 && str_contains($bodyLower, 'response_format') && str_contains($bodyLower, 'unsupported')) {
-            $fallback = $this->callOpenAI($apiKey, $audioPath, $model, 'text');
-            if ($fallback['ok']) {
-                return (string) $fallback['body'];
+        $transcriber = function (string $path) use ($apiKey, $audioPath, $model, $responseFormat) {
+            $resp = $this->callOpenAI($apiKey, $path, $model, $responseFormat);
+            if ($resp['ok']) {
+                return (string) $resp['body'];
             }
-            return 'Error: HTTP ' . $fallback['status'] . ', ' . substr($fallback['body'], 0, 2000);
-        }
 
-        return 'Error: HTTP ' . $resp['status'] . ', ' . substr($resp['body'], 0, 2000);
+            // If model rejects the format, fall back to 'text'
+            $bodyLower = strtolower($resp['body']);
+            if ($resp['status'] === 400 && str_contains($bodyLower, 'response_format') && str_contains($bodyLower, 'unsupported')) {
+                $fallback = $this->callOpenAI($apiKey, $path, $model, 'text');
+                if ($fallback['ok']) {
+                    return (string) $fallback['body'];
+                }
+                return 'Error: HTTP ' . $fallback['status'] . ', ' . substr($fallback['body'], 0, 2000);
+            }
+
+            return 'Error: HTTP ' . $resp['status'] . ', ' . substr($resp['body'], 0, 2000);
+        };
+
+        return \transcribe_with_chunks($audioPath, $transcriber);
     }
 
     private function callOpenAI(string $apiKey, string $audioPath, string $model, string $responseFormat): array

--- a/public_html/openai_transcribe.php
+++ b/public_html/openai_transcribe.php
@@ -66,59 +66,135 @@ function prepare_audio_for_openai(string $audioPath): array
 }
 
 /**
+ * Transcribe a potentially large audio file by chunking when necessary.
+ *
+ * The file is first passed through {@see prepare_audio_for_openai} to ensure
+ * it is encoded as a 64 kbps mono MP3 when large. If the prepared file still
+ * exceeds the OpenAI content limit, it is split into multiple segments using
+ * ffmpeg's segmenter. Each chunk is then passed to the supplied callback which
+ * performs the actual transcription. The resulting texts are concatenated with
+ * CRLF line endings.
+ *
+ * @param callable $transcribeFn function(string $path): string
+ */
+function transcribe_with_chunks(string $audioPath, callable $transcribeFn): string
+{
+    [$prepared, $mime, $tmp] = prepare_audio_for_openai($audioPath);
+
+    $maxSize = (int) getenv('OPENAI_MAX_CONTENT');
+    if ($maxSize <= 0) {
+        $maxSize = 26214400; // 25 MB default limit
+    }
+
+    $size = filesize($prepared);
+    if ($size !== false && $size > $maxSize) {
+        // Estimate duration for a 64 kbps MP3 (~8000 bytes/sec)
+        $seconds = max(1, (int) floor($maxSize / 8000));
+        $pattern = tempnam(sys_get_temp_dir(), 'wisper_chunk');
+        if ($pattern === false) {
+            if ($tmp && file_exists($tmp)) {
+                @unlink($tmp);
+            }
+            return 'Error: failed to create temp file';
+        }
+        $pattern .= '%03d.' . pathinfo($prepared, PATHINFO_EXTENSION);
+        $ffmpeg  = getenv('FFMPEG_BIN') ?: 'ffmpeg';
+        $cmd     = sprintf(
+            '%s -y -i %s -f segment -segment_time %d -c copy %s 2>&1',
+            escapeshellcmd($ffmpeg),
+            escapeshellarg($prepared),
+            $seconds,
+            escapeshellarg($pattern)
+        );
+        exec($cmd, $out, $code);
+        if ($code !== 0) {
+            if ($tmp && file_exists($tmp)) {
+                @unlink($tmp);
+            }
+            return 'Error: failed to split audio';
+        }
+        $chunks = glob(str_replace('%03d', '*', $pattern)) ?: [];
+        sort($chunks);
+        $texts = [];
+        foreach ($chunks as $chunk) {
+            $text = $transcribeFn($chunk);
+            @unlink($chunk);
+            if (str_starts_with($text, 'Error:')) {
+                if ($tmp && file_exists($tmp)) {
+                    @unlink($tmp);
+                }
+                return $text;
+            }
+            $texts[] = $text;
+        }
+        if ($tmp && file_exists($tmp)) {
+            @unlink($tmp);
+        }
+        return implode("\r\n", $texts);
+    }
+
+    $text = $transcribeFn($prepared);
+    if ($tmp && file_exists($tmp)) {
+        @unlink($tmp);
+    }
+    return $text;
+}
+
+/**
  * Transcribe the given audio file using OpenAI's Whisper API.
  */
 function openai_transcribe(string $audioPath): string
 {
-    $fake = getenv('OPENAI_TRANSCRIBE_FAKE');
-    if ($fake !== false) {
-        return $fake;
-    }
     if (!file_exists($audioPath)) {
         return 'Error: audio file not found';
     }
+
+    $fake = getenv('OPENAI_TRANSCRIBE_FAKE');
     $apiKey = getenv('OPENAI_API_KEY');
-    if ($apiKey === false || $apiKey === '') {
+    if ($fake === false && ($apiKey === false || $apiKey === '')) {
         return 'Error: missing API key';
     }
-    [$sendPath, $mime, $tmp] = prepare_audio_for_openai($audioPath);
-    $ch = curl_init('https://api.openai.com/v1/audio/transcriptions');
-    $cfile = curl_file_create($sendPath, $mime, basename($sendPath));
-    $data = [
-        'model' => 'whisper-1',
-        'file' => $cfile,
-        'response_format' => 'verbose_json',
-    ];
-    curl_setopt_array($ch, [
-        CURLOPT_RETURNTRANSFER => true,
-        CURLOPT_POST => true,
-        CURLOPT_HTTPHEADER => [
-            'Authorization: Bearer ' . $apiKey,
-        ],
-        CURLOPT_POSTFIELDS => $data,
-    ]);
-    $response = curl_exec($ch);
-    if ($response === false) {
-        $error = curl_error($ch);
+
+    $transcribeFn = function (string $path) use ($fake, $apiKey) {
+        if ($fake !== false) {
+            return $fake;
+        }
+
+        $ch = curl_init('https://api.openai.com/v1/audio/transcriptions');
+        $cfile = curl_file_create($path, 'audio/mpeg', basename($path));
+        $data = [
+            'model' => 'whisper-1',
+            'file'  => $cfile,
+            'response_format' => 'verbose_json',
+        ];
+        curl_setopt_array($ch, [
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_POST           => true,
+            CURLOPT_HTTPHEADER     => ['Authorization: Bearer ' . $apiKey],
+            CURLOPT_POSTFIELDS     => $data,
+        ]);
+        $response = curl_exec($ch);
+        if ($response === false) {
+            $error = curl_error($ch);
+            curl_close($ch);
+            return 'Error: ' . $error;
+        }
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
         curl_close($ch);
-        return 'Error: ' . $error;
-    }
-    $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-    curl_close($ch);
-    if ($tmp !== null) {
-        @unlink($tmp);
-    }
-    $json = json_decode($response, true);
-    if ($status !== 200 || !is_array($json)) {
-        return 'Error: API request failed';
-    }
-    if (isset($json['segments']) && is_array($json['segments'])) {
-        return format_transcript_segments($json['segments']);
-    }
-    if (isset($json['text'])) {
-        return (string) $json['text'];
-    }
-    return 'Error: API response missing text';
+        $json = json_decode((string) $response, true);
+        if ($status !== 200 || !is_array($json)) {
+            return 'Error: API request failed';
+        }
+        if (isset($json['segments']) && is_array($json['segments'])) {
+            return format_transcript_segments($json['segments']);
+        }
+        if (isset($json['text'])) {
+            return (string) $json['text'];
+        }
+        return 'Error: API response missing text';
+    };
+
+    return transcribe_with_chunks($audioPath, $transcribeFn);
 }
 
 if (realpath(__FILE__) === realpath($_SERVER['SCRIPT_FILENAME'])) {

--- a/tests/Feature/TranscribeWithChunksTest.php
+++ b/tests/Feature/TranscribeWithChunksTest.php
@@ -1,0 +1,56 @@
+<?php
+namespace Tests\Feature;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../../public_html/openai_transcribe.php';
+
+class TranscribeWithChunksTest extends TestCase
+{
+    public function testNoChunkForSmallFile(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'wisper') . '.wav';
+        file_put_contents($file, str_repeat('a', 10));
+        putenv('OPENAI_MAX_CONTENT=1000');
+        $calls = 0;
+        $result = transcribe_with_chunks($file, function (string $path) use (&$calls) {
+            $calls++;
+            return 'ok';
+        });
+        $this->assertSame('ok', $result);
+        $this->assertSame(1, $calls);
+        unlink($file);
+    }
+
+    public function testChunksLargeFile(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'wisper') . '.wav';
+        file_put_contents($file, str_repeat('a', 2000));
+
+        $ffmpeg = tempnam(sys_get_temp_dir(), 'ffmpeg');
+        file_put_contents($ffmpeg, "#!/bin/sh\n" .
+            "in=''\n" .
+            "while [ $# -gt 0 ]; do\n" .
+            "  if [ \"$1\" = '-i' ]; then in=$2; shift 2; continue; fi\n" .
+            "  out=$1; shift;\n" .
+            "done\n" .
+            "out0=$(printf \"$out\" 0)\n" .
+            "out1=$(printf \"$out\" 1)\n" .
+            "cp \"$in\" \"$out0\"\n" .
+            "cp \"$in\" \"$out1\"\n");
+        chmod($ffmpeg, 0755);
+        putenv('FFMPEG_BIN=' . $ffmpeg);
+        putenv('OPENAI_MAX_CONTENT=1000');
+
+        $calls = 0;
+        $result = transcribe_with_chunks($file, function (string $path) use (&$calls) {
+            $calls++;
+            return 'chunk';
+        });
+        $this->assertSame("chunk\r\nchunk", $result);
+        $this->assertSame(2, $calls);
+
+        unlink($file);
+        unlink($ffmpeg);
+    }
+}


### PR DESCRIPTION
## Summary
- Split large audio files into API-friendly chunks before sending to OpenAI
- Use chunk-aware transcription in `fill:wispertalk` command
- Document and test chunking behaviour

## Testing
- `phpunit --configuration phpunit.xml` *(fails: command not found)*
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b0289b88408331a2407af27cb070a8