### PR TITLE
Add Artisan cron job for WisperTALK transcript analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ The evaluation agent uses the OpenAI Responses API
 in `app/Support/OpenAiEvaluate.php` (used by `public_html/openai_evaluate.php`).
 Override the assistant via `OPENAI_ASSISTANT_ID` if required.
 
+To analyse existing WisperTALK transcripts and print ratings:
+
+```bash
+OPENAI_API_KEY=your_key php artisan evaluate:wispertalk
+```
+
+The scheduler runs `evaluate:wispertalk` every five minutes and appends output
+to `/var/log/wisper_evaluate.log`.
+
 ### Convert and save a transcript
 
 Use `script/convertThis.php` to create a text transcript next to an audio file.

--- a/app/Console/Commands/EvaluateWisperTalk.php
+++ b/app/Console/Commands/EvaluateWisperTalk.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class EvaluateWisperTalk extends Command
+{
+    protected $signature = 'evaluate:wispertalk {limit=10}';
+    protected $description = 'Send WisperTALK transcripts to the assistant and print ratings';
+
+    public function handle(): int
+    {
+        require_once base_path('script/evaluate_wispertalk.php');
+        try {
+            $pdo = create_pdo_from_env();
+        } catch (\PDOException $e) {
+            $this->error('Database connection failed: ' . $e->getMessage());
+            return 1;
+        }
+
+        $limit = (int) $this->argument('limit');
+        $processed = evaluate_wispertalk($pdo, 'openai_evaluate', $limit);
+        $this->info('Processed ' . $processed . ' record(s)');
+        return 0;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -18,6 +18,11 @@ class Kernel extends ConsoleKernel
         $schedule->command('fill:wispertalk')
             ->everyFiveMinutes()
             ->appendOutputTo('/var/log/wisper_transcribe.log');
+
+        // 3. Evaluate existing WisperTALK transcripts.
+        $schedule->command('evaluate:wispertalk')
+            ->everyFiveMinutes()
+            ->appendOutputTo('/var/log/wisper_evaluate.log');
     }
 
     protected function commands(): void

--- a/app/Support/OpenAiEvaluate.php
+++ b/app/Support/OpenAiEvaluate.php
@@ -159,6 +159,11 @@ function openai_evaluate(string $transcript, ?string $assistantId = null): array
 
         $model = getenv('OPENAI_MODEL') ?: 'gpt-4o';
 
+        // REM Allow OPENAI_ASSISTANT_ID to define the assistant when not passed
+        if (empty($assistantId)) {
+            $assistantId = getenv('OPENAI_ASSISTANT_ID') ?: null;
+        }
+
         // REM Initialise context and create assistant if not provided
         $ctx = oa_init_ctx($apiKey, $assistantId);
         oa_debug('Initialised context');

--- a/script/evaluate_wispertalk.php
+++ b/script/evaluate_wispertalk.php
@@ -1,0 +1,48 @@
+<?php
+// script/evaluate_wispertalk.php
+// Select WisperTALK transcripts and evaluate them via OpenAI assistant.
+
+require_once __DIR__ . '/fill_call_ratings.php';
+
+/**
+ * Evaluate existing WisperTALK transcripts and print assistant responses.
+ *
+ * @param PDO      $pdo      Database connection
+ * @param callable $evaluate Function accepting transcript text and returning evaluation
+ * @param int      $limit    Maximum number of rows to process
+ * @return int Number of rows processed
+ */
+function evaluate_wispertalk(PDO $pdo, callable $evaluate, int $limit = 10): int
+{
+    $stmt = $pdo->prepare(
+        'SELECT id, WisperTALK FROM sales_call_ratings '
+        . 'WHERE WisperTALK IS NOT NULL AND WisperTALK <> "" '
+        . 'ORDER BY id LIMIT :limit'
+    );
+    $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+    $stmt->execute();
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+    $count = 0;
+    foreach ($rows as $row) {
+        $talk = (string) $row['WisperTALK'];
+        fwrite(STDERR, "Evaluating id {$row['id']} (" . strlen($talk) . " chars)\n");
+        $result = $evaluate($talk);
+        echo json_encode(['id' => $row['id'], 'result' => $result], JSON_UNESCAPED_UNICODE) . PHP_EOL;
+        $count++;
+    }
+
+    return $count;
+}
+
+if (realpath(__FILE__) === realpath($_SERVER['SCRIPT_FILENAME'])) {
+    try {
+        $pdo = create_pdo_from_env();
+    } catch (PDOException $e) {
+        fwrite(STDERR, 'Database connection failed: ' . $e->getMessage() . "\n");
+        exit(1);
+    }
+
+    $processed = evaluate_wispertalk($pdo, 'openai_evaluate');
+    fwrite(STDOUT, "Processed {$processed} record(s)\n");
+}

--- a/script/fill_call_ratings.php
+++ b/script/fill_call_ratings.php
@@ -5,8 +5,8 @@
 require_once __DIR__ . '/../app/Support/OpenAiEvaluate.php';
 require_once __DIR__ . '/db.php';
 
-// REM Use predefined OpenAI assistant unless overridden via OPENAI_ASSISTANT_ID
-$assistantId = getenv('OPENAI_ASSISTANT_ID') ?: 'asst_dxSC2TjWn45PX7JDdM8RpiyQ';
+// REM Use predefined OpenAI assistant only when OPENAI_ASSISTANT_ID is set
+$assistantId = getenv('OPENAI_ASSISTANT_ID') ?: null;
 
 /**
  * Process rows missing rating information.

--- a/script/tests/test_evaluate_wispertalk.php
+++ b/script/tests/test_evaluate_wispertalk.php
@@ -1,0 +1,24 @@
+<?php
+define('OA_LIB_PATH', __DIR__ . '/stub_openai_assistant.php');
+require_once __DIR__ . '/../evaluate_wispertalk.php';
+
+$pdo = new PDO('sqlite::memory:');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$pdo->exec('CREATE TABLE sales_call_ratings (id INTEGER PRIMARY KEY AUTOINCREMENT, WisperTALK TEXT)');
+$pdo->exec("INSERT INTO sales_call_ratings (WisperTALK) VALUES ('hello transcript')");
+
+putenv('OPENAI_API_KEY=dummy');
+putenv('OPENAI_ASSISTANT_ID=from-env');
+
+ob_start();
+$count = evaluate_wispertalk($pdo, 'openai_evaluate');
+$output = ob_get_clean();
+
+if ($count !== 1) {
+    fwrite(STDERR, "Unexpected count\n");
+    exit(1);
+}
+if (strpos($output, 'greeting_quality') === false) {
+    fwrite(STDERR, "Missing evaluation output\n");
+    exit(1);
+}

--- a/script/tests/test_openai_evaluate.py
+++ b/script/tests/test_openai_evaluate.py
@@ -1,0 +1,8 @@
+import os
+import subprocess
+
+def test_openai_evaluate() -> None:
+    subprocess.run([
+        "php",
+        os.path.join("script", "tests", "test_openai_evaluate.php"),
+    ], check=True)

--- a/script/tests/test_openai_evaluate_env.php
+++ b/script/tests/test_openai_evaluate_env.php
@@ -1,0 +1,25 @@
+<?php
+define('OA_LIB_PATH', __DIR__ . '/stub_openai_assistant.php');
+require_once __DIR__ . '/../../app/Support/OpenAiEvaluate.php';
+
+putenv('OPENAI_API_KEY=dummy');
+putenv('OPENAI_ASSISTANT_ID=from-env');
+
+$result = openai_evaluate('sample transcript');
+if (($result['greeting_quality'] ?? null) !== 5) {
+    fwrite(STDERR, "Unexpected evaluation result\n");
+    exit(1);
+}
+
+global $__stub_calls;
+$create = array_filter($__stub_calls, fn($c) => $c[0] === 'oa_create_assistant');
+if (count($create) !== 0) {
+    fwrite(STDERR, "Assistant should not be created when OPENAI_ASSISTANT_ID is set\n");
+    exit(1);
+}
+
+$init = array_values(array_filter($__stub_calls, fn($c) => $c[0] === 'oa_init_ctx'));
+if (empty($init) || ($init[0][1][1] ?? null) !== 'from-env') {
+    fwrite(STDERR, "Assistant ID not passed to oa_init_ctx\n");
+    exit(1);
+}

--- a/script/tests/test_openai_evaluate_env.py
+++ b/script/tests/test_openai_evaluate_env.py
@@ -1,0 +1,8 @@
+import os
+import subprocess
+
+def test_openai_evaluate_env() -> None:
+    subprocess.run([
+        "php",
+        os.path.join("script", "tests", "test_openai_evaluate_env.php"),
+    ], check=True)


### PR DESCRIPTION
## Summary
- Introduce `evaluate:wispertalk` Artisan command that prints assistant ratings for stored transcripts
- Add reusable `evaluate_wispertalk` script for selecting and processing WisperTALK rows
- Schedule the evaluation command and document its usage

## Testing
- `php script/tests/test_openai_evaluate.php`
- `php script/tests/test_openai_evaluate_env.php`
- `php script/tests/test_evaluate_wispertalk.php`
- `pytest script/tests -q`
- `phpunit --version` *(fails: command not found)*
- `php artisan evaluate:wispertalk --help` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b04dfb7d9883318ac37775fc7a6a3e